### PR TITLE
Remove column names

### DIFF
--- a/R/H2_jk.R
+++ b/R/H2_jk.R
@@ -68,8 +68,6 @@
 #' H2_jk(inter, normalize = FALSE, squared = FALSE)  
 #' 
 #' \dontrun{
-#' H2_jk(fit, v = names(iris[-1]), X = iris, verbose = FALSE)
-#' 
 #' # MODEL TWO: Multi-response linear regression
 #' fit <- lm(as.matrix(iris[1:2]) ~ Petal.Length + Petal.Width * Species, data = iris)
 #' v <- c("Petal.Length", "Petal.Width", "Species")
@@ -93,8 +91,9 @@ H2_jk.interact <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE
   combs <- object[["combs"]]
   n_combs <- length(combs)
   nms <- colnames(object[["f"]])
+  p <- ncol(object[["f"]])
   num <- denom <- matrix(
-    nrow = n_combs, ncol = length(nms), dimnames = list(names(combs), nms)
+    nrow = n_combs, ncol = p, dimnames = list(names(combs), nms)
   )
   for (i in seq_len(n_combs)) {
     z <- combs[[i]]

--- a/R/interact.R
+++ b/R/interact.R
@@ -29,7 +29,7 @@
 #'     functions \eqn{F_{\setminus j}} of other features.
 #'   - `F_jk`: List of matrices, each representing (centered) bivariate 
 #'     partial dependence functions \eqn{F_{jk}}.
-#'   - `w`: Same as input `w.
+#'   - `w`: Same as input `w`.
 #'   - `v`: Same as input `v`.
 #'   - `v_pairwise`: Subset of `v` with largest `H2_j` used for pairwise calculations.
 #'   - `combs`: Named list of variable pairs for which pairwise partial 

--- a/R/pd.R
+++ b/R/pd.R
@@ -82,9 +82,9 @@ partial_dep <- function(object, ...) {
 #' @describeIn partial_dep Default method.
 #' @export
 partial_dep.default <- function(object, v, X, pred_fun = stats::predict,
-                       grid = NULL, grid_size = 36L, trim = c(0.01, 0.99), 
-                       strategy = c("quantile", "uniform"), 
-                       n_max = 1000L, w = NULL, ...) {
+                                grid = NULL, grid_size = 36L, trim = c(0.01, 0.99), 
+                                strategy = c("quantile", "uniform"), 
+                                n_max = 1000L, w = NULL, ...) {
   basic_check(X = X, v = v, pred_fun = pred_fun, w = w)
   
   if (is.null(grid)) {
@@ -115,6 +115,12 @@ partial_dep.default <- function(object, v, X, pred_fun = stats::predict,
     compress_grid = FALSE,  # Almost always unique, so we save a check for uniqueness
     ...
   )
+  if (is.null(colnames(pd))) {
+    K <- ncol(pd)
+    colnames(pd) <- if (K == 1L) "y" else paste0("y", seq_len(K))
+  }
+  
+  # Organize output
   if (!is.data.frame(grid) && !is.matrix(grid)) {
     grid <- stats::setNames(as.data.frame(grid), v)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 #' Aligns Predictions
 #' 
-#' Turns predictions into matrix with column names.
+#' Turns predictions into matrix.
 #' 
 #' @noRd
 #' @keywords internal
@@ -13,10 +13,6 @@ align_pred <- function(x) {
   }
   if (!is.numeric(x)) {
     stop("Predictions must be numeric")
-  }
-  if (is.null(colnames(x))) {
-    p <- ncol(x)
-    colnames(x) <- if (p == 1L) "y" else paste0("y", seq_len(p))
   }
   x
 }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ fit <- xgb.train(
   nrounds = 1000,
   callbacks = list(cb.print.evaluation(period = 100))
 )
+
 ```
 
 ### Analyze interactions 
@@ -96,7 +97,7 @@ We will now do two things:
 2. Get statistics with `summary()`.
 
 ```r
-# 2 seconds on simple laptop - a random forest will take 1-2 minutes
+# 2-3 seconds on simple laptop - a random forest will take 1-2 minutes
 set.seed(1)
 system.time(
   inter <- interact(fit, v = x, X = X_train)
@@ -106,11 +107,10 @@ summary(inter)
 
 # Output
 Proportion of prediction variability explained by interactions
-         y 
 0.09602024 
 
 Strongest overall interactions
-                            y
+                         [,1]
 OCEAN_DIST        0.062639450
 LONGITUDE         0.045194768
 LATITUDE          0.029151873
@@ -124,7 +124,7 @@ age               0.000000000
 
 Strongest relative pairwise interactions
 (only for features with strong overall interactions)
-                               y
+                            [,1]
 LONGITUDE:OCEAN_DIST 0.156475264
 LONGITUDE:CNTR_DIST  0.122113602
 LATITUDE:LONGITUDE   0.076213847
@@ -153,7 +153,7 @@ Strongest pairwise interactions (values on the scale of the response log(price))
 
 ```r
 H2_jk(inter, normalize = FALSE, squared = FALSE, top_m = 5)
-                              y
+                           [,1]
 LONGITUDE:OCEAN_DIST 0.08279401
 LATITUDE:OCEAN_DIST  0.04797644
 LONGITUDE:CNTR_DIST  0.04796194

--- a/man/H2_jk.Rd
+++ b/man/H2_jk.Rd
@@ -110,8 +110,6 @@ H2_jk(inter)
 H2_jk(inter, normalize = FALSE, squared = FALSE)  
 
 \dontrun{
-H2_jk(fit, v = names(iris[-1]), X = iris, verbose = FALSE)
-
 # MODEL TWO: Multi-response linear regression
 fit <- lm(as.matrix(iris[1:2]) ~ Petal.Length + Petal.Width * Species, data = iris)
 v <- c("Petal.Length", "Petal.Width", "Species")

--- a/man/interact.Rd
+++ b/man/interact.Rd
@@ -85,7 +85,7 @@ partial dependence functions \eqn{F_j}.
 functions \eqn{F_{\setminus j}} of other features.
 \item \code{F_jk}: List of matrices, each representing (centered) bivariate
 partial dependence functions \eqn{F_{jk}}.
-\item \code{w}: Same as input `w.
+\item \code{w}: Same as input \code{w}.
 \item \code{v}: Same as input \code{v}.
 \item \code{v_pairwise}: Subset of \code{v} with largest \code{H2_j} used for pairwise calculations.
 \item \code{combs}: Named list of variable pairs for which pairwise partial


### PR DESCRIPTION
Column names of resulting matrix/vectors will now be NULL instead of "y", "y1", ... in case the prediction function does not provide names.