### PR TITLE
Docu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## New major features
 
-- **average_loss()**: This new function calculates the average loss of a model for a given dataset, optionally grouped by a discrete vector. It supports the most important loss functions (squared error, Poisson deviance, Gamma deviance, Log loss, multivariate Log loss, absolute error), and allows for case weights. Custom losses can be passed as vector/matrix valued functions of signature `f(obs, pred)`.
+- **average_loss()**: This new function calculates the average loss of a model for a given dataset, optionally grouped by a discrete vector. It supports the most important loss functions (squared error, Poisson deviance, Gamma deviance, Log loss, multivariate Log loss, absolute error, classification error), and allows for case weights. Custom losses can be passed as vector/matrix valued functions of signature `f(obs, pred)`.
+Note that such a custom function needs to return per-row losses, not their average.
 
 - **perm_importance()**: H-statistics are often calculated for important features only. To support this workflow, we have added permutation importance regarding the most important loss functions. Multivariate losses can be studied individually or collapsed over dimensions. The importance of *feature groups* can be studied as well. Note that the API is different from the experimental `pd_importance()`, which is calculated from a "hstats" object, while `perm_importance()` acts on the fitted model.
 

--- a/R/average_loss.R
+++ b/R/average_loss.R
@@ -20,17 +20,24 @@
 #'   a (n x K) matrix of probabilities (with row-sums 1).
 #'   The observed values `y` are either passed as (n x K) dummy matrix, 
 #'   or as discrete vector with corresponding levels. 
-#'   The latter case is turned into a dummy matrix via `model.matrix(~ y + 0)`
+#'   The latter case is turned into a dummy matrix via `model.matrix(~ y + 0)`.
+#' - "classification_error": Misclassification error. This is currently the
+#'   only prespecified loss that accepts non-numeric predictions. Both the 
+#'   observed values `y` and the predictions can be character/factor. This
+#'   loss function can be used in non-probabilistic classification settings.
+#'   BUT: Probabilistic classification (with "mlogloss") is preferred.
 #' - A function with signature `f(actual, predicted)`, returning a numeric 
 #'   vector of length n or a matrix with n rows, where n is the number of rows of `X`.
 #'
 #' @inheritParams hstats
-#' @param y Numeric vector or matrix of the response corresponding to `X`.
+#' @param y Vector/matrix of the response corresponding to `X`.
 #' @param loss One of "squared_error", "logloss", "mlogloss", "poisson",
-#'   "gamma", "absolute_error", or a loss function that turns observed and predicted 
-#'   values (vectors or matrices) into a vector or matrix of unit losses.
-#'   For "mlogloss", the response `y` can either be a dummy matrix, or a vector with 
-#'   categories. The latter case is handled via `model.matrix(~ y + 0)`.
+#'   "gamma", "absolute_error", "classification_error". Alternatively, a loss function 
+#'   can be provided that turns observed and predicted values into a numeric vector or 
+#'   matrix of unit losses of the same length as `X`.
+#'   For "mlogloss", the response `y` can either be a dummy matrix or a discrete vector. 
+#'   The latter case is handled via `model.matrix(~ y + 0)`.
+#'   For "classification_error", both predictions and responses can be non-numeric.
 #' @param BY Optional grouping vector.
 #' @returns A matrix with one row per group and one column per loss dimension.
 #' @export
@@ -70,14 +77,12 @@ average_loss.default <- function(object, X, y,
   if (!is.function(loss) && loss == "mlogloss" && NCOL(y) == 1L) {
     y <- stats::model.matrix(~y + 0)
   }
-  if (!is.matrix(y)) {
-    y <- as.matrix(y)
-  }
   if (!is.function(loss)) {
     loss <- get_loss_fun(loss)
   }
   
-  L <- loss(y, align_pred(pred_fun(object, X, ...)))
+  # Real work
+  L <- as.matrix(loss(y, pred_fun(object, X, ...)))
   gwColMeans(L, g = BY, w = w)
 }
 

--- a/R/average_loss.R
+++ b/R/average_loss.R
@@ -1,16 +1,36 @@
 #' Average Loss
 #'
-#' Calculates average loss, optionally grouped by a discrete vector. 
-#' The function supports multivariate losses and case weights.
+#' Calculates the average loss of a model on a given dataset, 
+#' optionally grouped by a discrete vector.
+#' 
+#' @section Losses: 
+#' 
+#' The default `loss` is the "squared_error". Other choices: 
+#' - "absolute_error": The absolute error is the loss corresponding to median regression. 
+#' - "poisson": Unit Poisson deviance, i.e., the loss function used in 
+#'   Poisson regression. Actual values `y` and predictions must be non-negative.
+#' - "gamma": Unit gamma deviance, i.e., the loss function of Gamma regression.
+#'   Actual values `y` and predictions must be positive.
+#' - "logloss": The Log Loss is the loss function used in logistic regression,
+#'   and the top choice in probabilistic binary classification. Responses `y` and
+#'   predictions must be between 0 and 1. Predictions represent probabilities of 
+#'   having a "1".
+#' - "mlogloss": Multi-Log-Loss is the natural loss function in probabilistic multi-class 
+#'   situations. If there are K classes and n observations, the predictions form
+#'   a (n x K) matrix of probabilities (with row-sums 1).
+#'   The observed values `y` are either passed as (n x K) dummy matrix, 
+#'   or as discrete vector with corresponding levels. 
+#'   The latter case is turned into a dummy matrix via `model.matrix(~ y + 0)`
+#' - A function with signature `f(actual, predicted)`, returning a numeric 
+#'   vector of length n or a matrix with n rows, where n is the number of rows of `X`.
 #'
 #' @inheritParams hstats
 #' @param y Numeric vector or matrix of the response corresponding to `X`.
 #' @param loss One of "squared_error", "logloss", "mlogloss", "poisson",
 #'   "gamma", "absolute_error", or a loss function that turns observed and predicted 
 #'   values (vectors or matrices) into a vector or matrix of unit losses.
-#'   For "mlogloss", the response `y` can either be a matrix with one column per category
-#'   or a vector with categories. The latter case is internally exploded to the shape
-#'   of the predictions via `stats::model.matrix(~ y + 0)`.
+#'   For "mlogloss", the response `y` can either be a dummy matrix, or a vector with 
+#'   categories. The latter case is handled via `model.matrix(~ y + 0)`.
 #' @param BY Optional grouping vector.
 #' @returns A matrix with one row per group and one column per loss dimension.
 #' @export

--- a/R/hstats.R
+++ b/R/hstats.R
@@ -25,7 +25,7 @@
 #' @param v Vector of feature names.
 #' @param X A data.frame or matrix serving as background dataset.
 #' @param pred_fun Prediction function of the form `function(object, X, ...)`,
-#'   providing \eqn{K \ge 1} numeric predictions per row. Its first argument represents the 
+#'   providing \eqn{K \ge 1} predictions per row. Its first argument represents the 
 #'   model `object`, its second argument a data structure like `X`. Additional arguments 
 #'   (such as `type = "response"` in a GLM) can be passed via `...`. The default, 
 #'   [stats::predict()], will work in most cases. Note that column names in a resulting

--- a/R/losses.R
+++ b/R/losses.R
@@ -7,7 +7,7 @@
 #'
 #' @param actual A numeric vector/matrix.
 #' @param predicted A numeric vector/matrix.
-#' @returns Vector or matrix of losses.
+#' @returns Vector or matrix of numeric losses.
 loss_squared_error <- function(actual, predicted) {
   check_dim(actual = actual, predicted = predicted)
   (actual - predicted)^2
@@ -22,7 +22,7 @@ loss_squared_error <- function(actual, predicted) {
 #'
 #' @param actual A numeric vector/matrix.
 #' @param predicted A numeric vector/matrix.
-#' @returns Vector or matrix of losses.
+#' @returns Vector or matrix of numeric losses.
 loss_absolute_error <- function(actual, predicted) {
   check_dim(actual = actual, predicted = predicted)
   abs(actual - predicted)
@@ -37,7 +37,7 @@ loss_absolute_error <- function(actual, predicted) {
 #'
 #' @param actual A numeric vector/matrix with non-negative values.
 #' @param predicted A numeric vector/matrix with non-negative values.
-#' @returns Vector or matrix of losses.
+#' @returns Vector or matrix of numeric losses.
 loss_poisson <- function(actual, predicted) {
   check_dim(actual = actual, predicted = predicted)
   stopifnot(
@@ -59,7 +59,7 @@ loss_poisson <- function(actual, predicted) {
 #'
 #' @param actual A numeric vector/matrix with positive values.
 #' @param predicted A numeric vector/matrix with positive values.
-#' @returns Vector or matrix of losses.
+#' @returns Vector or matrix of numeric losses.
 loss_gamma <- function(actual, predicted) {
   check_dim(actual = actual, predicted = predicted)
   stopifnot(
@@ -67,6 +67,21 @@ loss_gamma <- function(actual, predicted) {
     all(actual > 0)
   )
   -2 * (log(actual / predicted) - (actual - predicted) / predicted)
+}
+
+#' Classification Error Loss
+#' 
+#' Internal function. Calculates per-row misclassification errors.
+#' 
+#' @noRd
+#' @keywords internal
+#'
+#' @param actual A vector/matrix with discrete values.
+#' @param predicted A vector/matrix with discrete values.
+#' @returns Vector or matrix of numeric losses.
+loss_classification_error <- function(actual, predicted) {
+  check_dim(actual = actual, predicted = predicted)
+  (actual != predicted) * 1.0
 }
 
 #' Log Loss
@@ -79,7 +94,7 @@ loss_gamma <- function(actual, predicted) {
 #'
 #' @param actual A numeric vector/matrix with values between 0 and 1.
 #' @param predicted A numeric vector/matrix with values between 0 and 1.
-#' @returns Vector or matrix of losses.
+#' @returns Vector or matrix of numeric losses.
 loss_logloss <- function(actual, predicted) {
   check_dim(actual = actual, predicted = predicted)
   stopifnot(
@@ -167,6 +182,7 @@ get_loss_fun <- function(loss) {
     poisson = loss_poisson,
     gamma = loss_gamma,
     absolute_error = loss_absolute_error,
+    classification_error = loss_classification_error,
     stop("Unknown loss function.")
   )
 }

--- a/R/perm_importance.R
+++ b/R/perm_importance.R
@@ -74,11 +74,8 @@ perm_importance.default <- function(object, v, X, y,
   if (!is.function(loss) && loss == "mlogloss" && NCOL(y) == 1L) {
     y <- stats::model.matrix(~y + 0)
   }
-  if (!is.matrix(y)) {
-    y <- as.matrix(y)
-  }
   stopifnot(
-    nrow(y) == nrow(X),
+    NROW(y) == nrow(X),
     perms >= 1L
   )
   
@@ -86,7 +83,11 @@ perm_importance.default <- function(object, v, X, y,
   if (nrow(X) > n_max) {
     ix <- sample(nrow(X), n_max)
     X <- X[ix, , drop = FALSE]
-    y <- y[ix, , drop = FALSE]
+    if (is.vector(y) || is.factor(y)) {
+      y <- y[ix]
+    } else {
+      y <- y[ix, , drop = FALSE]
+    }
     if (!is.null(w)) {
       w <- w[ix]
     }
@@ -103,24 +104,24 @@ perm_importance.default <- function(object, v, X, y,
   }
   
   # Pre-shuffle performance
-  L <- loss(y, align_pred(pred_fun(object, X, ...)))
+  L <- as.matrix(loss(y, pred_fun(object, X, ...)))
   perf <- wcolMeans(L, w = w)
 
   # Stack y and X m times
   if (perms > 1L) {
     ind <- rep(seq_len(n), times = perms)
     X <- X[ind, , drop = FALSE]
-    y <- y[ind, , drop = FALSE]
+    if (is.vector(y) || is.factor(y)) {
+      y <- y[ind]
+    } else {
+      y <- y[ind, , drop = FALSE]
+    }
   }
   
   shuffle_perf <- function(z, XX) {
     ind <- c(replicate(perms, sample(seq_len(n))))
-    if (is.data.frame(XX) && length(z) == 1L) {
-      XX[[z]] <- XX[[z]][ind]  # a bit faster
-    } else {
-      XX[, z] <- XX[ind, z]
-    }
-    L <- loss(y, align_pred(pred_fun(object, XX, ...)))
+    XX[, z] <- XX[ind, z]
+    L <- as.matrix(loss(y, pred_fun(object, XX, ...)))
     t(wrowmean(L, ngroups = perms, w = w))
   }
   

--- a/R/perm_importance.R
+++ b/R/perm_importance.R
@@ -1,25 +1,25 @@
 #' Permutation Importance
-#'
-#' Calculates permutation feature importance (PVI) for a set of features or 
-#' a set of feature groups.
 #' 
-#' The PVI of a feature is defined as the increase in average loss when
-#' shuffling the corresponding column before calculating predictions.
-#' The loss function can be specified as a string ("squared_error", "mlogloss", etc.)
-#' or a vector/matrix valued function. Note that the model is never refitted.
-#' Multivariate losses can be collapsed over columns (default) or analyzed separately.
+#' Calculates permutation feature importance (PVI) for a set of features or 
+#' a set of feature groups `v`.
+#' 
+#' The PVI of a feature is defined as the increase in the average loss when
+#' shuffling the corresponding feature values before calculating predictions.
+#' By default, the process is repeated `perms = 4` times, and the results are averaged.
+#' 
+#' @inheritSection average_loss Losses
 #' 
 #' @param v Vector of feature names, or named list of feature groups.
 #' @param perms Number of permutations (default 4).
 #' @param agg_cols Should multivariate losses be summed up? Default is `FALSE`.
-#' @param normalize Should importance statistics be divided by performance?
+#' @param normalize Should importance statistics be divided by average loss?
 #'   Default is `FALSE`. If `TRUE`, an importance of 1 means that the average loss
 #'   has doubled by shuffling that feature's column.
 #' @inheritParams hstats
 #' @inheritParams average_loss
 #' @returns
 #'   An object of class "perm_importance" containing these elements:
-#'   - `imp`: (p x d) matrix containing the sorted importance values, i.e.,
+#'   - `imp`: (p x d) matrix containing the sorted (average) importance values, i.e.,
 #'     a row per feature (group) and a column per loss dimension.
 #'   - `SE`: (p x d) matrix with corresponding standard errors of `imp`.
 #'      Multiply with `sqrt(perms)` to get standard deviations.

--- a/man/average_loss.Rd
+++ b/man/average_loss.Rd
@@ -63,10 +63,10 @@ for instance \code{type = "response"} in a \code{\link[=glm]{glm()}} model.}
 
 \item{X}{A data.frame or matrix serving as background dataset.}
 
-\item{y}{Numeric vector or matrix of the response corresponding to \code{X}.}
+\item{y}{Vector/matrix of the response corresponding to \code{X}.}
 
 \item{pred_fun}{Prediction function of the form \verb{function(object, X, ...)},
-providing \eqn{K \ge 1} numeric predictions per row. Its first argument represents the
+providing \eqn{K \ge 1} predictions per row. Its first argument represents the
 model \code{object}, its second argument a data structure like \code{X}. Additional arguments
 (such as \code{type = "response"} in a GLM) can be passed via \code{...}. The default,
 \code{\link[stats:predict]{stats::predict()}}, will work in most cases. Note that column names in a resulting
@@ -75,10 +75,12 @@ matrix of predictions will be used as default column names in the results.}
 \item{BY}{Optional grouping vector.}
 
 \item{loss}{One of "squared_error", "logloss", "mlogloss", "poisson",
-"gamma", "absolute_error", or a loss function that turns observed and predicted
-values (vectors or matrices) into a vector or matrix of unit losses.
-For "mlogloss", the response \code{y} can either be a dummy matrix, or a vector with
-categories. The latter case is handled via \code{model.matrix(~ y + 0)}.}
+"gamma", "absolute_error", "classification_error". Alternatively, a loss function
+can be provided that turns observed and predicted values into a numeric vector or
+matrix of unit losses of the same length as \code{X}.
+For "mlogloss", the response \code{y} can either be a dummy matrix or a discrete vector.
+The latter case is handled via \code{model.matrix(~ y + 0)}.
+For "classification_error", both predictions and responses can be non-numeric.}
 
 \item{w}{Optional vector of case weights for each row of \code{X}.}
 
@@ -121,7 +123,12 @@ situations. If there are K classes and n observations, the predictions form
 a (n x K) matrix of probabilities (with row-sums 1).
 The observed values \code{y} are either passed as (n x K) dummy matrix,
 or as discrete vector with corresponding levels.
-The latter case is turned into a dummy matrix via \code{model.matrix(~ y + 0)}
+The latter case is turned into a dummy matrix via \code{model.matrix(~ y + 0)}.
+\item "classification_error": Misclassification error. This is currently the
+only prespecified loss that accepts non-numeric predictions. Both the
+observed values \code{y} and the predictions can be character/factor. This
+loss function can be used in non-probabilistic classification settings.
+BUT: Probabilistic classification (with "mlogloss") is preferred.
 \item A function with signature \code{f(actual, predicted)}, returning a numeric
 vector of length n or a matrix with n rows, where n is the number of rows of \code{X}.
 }

--- a/man/average_loss.Rd
+++ b/man/average_loss.Rd
@@ -77,9 +77,8 @@ matrix of predictions will be used as default column names in the results.}
 \item{loss}{One of "squared_error", "logloss", "mlogloss", "poisson",
 "gamma", "absolute_error", or a loss function that turns observed and predicted
 values (vectors or matrices) into a vector or matrix of unit losses.
-For "mlogloss", the response \code{y} can either be a matrix with one column per category
-or a vector with categories. The latter case is internally exploded to the shape
-of the predictions via \code{stats::model.matrix(~ y + 0)}.}
+For "mlogloss", the response \code{y} can either be a dummy matrix, or a vector with
+categories. The latter case is handled via \code{model.matrix(~ y + 0)}.}
 
 \item{w}{Optional vector of case weights for each row of \code{X}.}
 
@@ -89,8 +88,8 @@ of the predictions via \code{stats::model.matrix(~ y + 0)}.}
 A matrix with one row per group and one column per loss dimension.
 }
 \description{
-Calculates average loss, optionally grouped by a discrete vector.
-The function supports multivariate losses and case weights.
+Calculates the average loss of a model on a given dataset,
+optionally grouped by a discrete vector.
 }
 \section{Methods (by class)}{
 \itemize{
@@ -103,6 +102,31 @@ The function supports multivariate losses and case weights.
 \item \code{average_loss(explainer)}: Method for DALEX "explainer".
 
 }}
+\section{Losses}{
+
+
+The default \code{loss} is the "squared_error". Other choices:
+\itemize{
+\item "absolute_error": The absolute error is the loss corresponding to median regression.
+\item "poisson": Unit Poisson deviance, i.e., the loss function used in
+Poisson regression. Actual values \code{y} and predictions must be non-negative.
+\item "gamma": Unit gamma deviance, i.e., the loss function of Gamma regression.
+Actual values \code{y} and predictions must be positive.
+\item "logloss": The Log Loss is the loss function used in logistic regression,
+and the top choice in probabilistic binary classification. Responses \code{y} and
+predictions must be between 0 and 1. Predictions represent probabilities of
+having a "1".
+\item "mlogloss": Multi-Log-Loss is the natural loss function in probabilistic multi-class
+situations. If there are K classes and n observations, the predictions form
+a (n x K) matrix of probabilities (with row-sums 1).
+The observed values \code{y} are either passed as (n x K) dummy matrix,
+or as discrete vector with corresponding levels.
+The latter case is turned into a dummy matrix via \code{model.matrix(~ y + 0)}
+\item A function with signature \code{f(actual, predicted)}, returning a numeric
+vector of length n or a matrix with n rows, where n is the number of rows of \code{X}.
+}
+}
+
 \examples{
 # MODEL 1: Linear regression
 fit <- lm(Sepal.Length ~ ., data = iris)

--- a/man/hstats.Rd
+++ b/man/hstats.Rd
@@ -73,7 +73,7 @@ for instance \code{type = "response"} in a \code{\link[=glm]{glm()}} model.}
 \item{X}{A data.frame or matrix serving as background dataset.}
 
 \item{pred_fun}{Prediction function of the form \verb{function(object, X, ...)},
-providing \eqn{K \ge 1} numeric predictions per row. Its first argument represents the
+providing \eqn{K \ge 1} predictions per row. Its first argument represents the
 model \code{object}, its second argument a data structure like \code{X}. Additional arguments
 (such as \code{type = "response"} in a GLM) can be passed via \code{...}. The default,
 \code{\link[stats:predict]{stats::predict()}}, will work in most cases. Note that column names in a resulting

--- a/man/ice.Rd
+++ b/man/ice.Rd
@@ -77,7 +77,7 @@ for instance \code{type = "response"} in a \code{\link[=glm]{glm()}} model.}
 \item{X}{A data.frame or matrix serving as background dataset.}
 
 \item{pred_fun}{Prediction function of the form \verb{function(object, X, ...)},
-providing \eqn{K \ge 1} numeric predictions per row. Its first argument represents the
+providing \eqn{K \ge 1} predictions per row. Its first argument represents the
 model \code{object}, its second argument a data structure like \code{X}. Additional arguments
 (such as \code{type = "response"} in a GLM) can be passed via \code{...}. The default,
 \code{\link[stats:predict]{stats::predict()}}, will work in most cases. Note that column names in a resulting

--- a/man/partial_dep.Rd
+++ b/man/partial_dep.Rd
@@ -85,7 +85,7 @@ for instance \code{type = "response"} in a \code{\link[=glm]{glm()}} model.}
 \item{X}{A data.frame or matrix serving as background dataset.}
 
 \item{pred_fun}{Prediction function of the form \verb{function(object, X, ...)},
-providing \eqn{K \ge 1} numeric predictions per row. Its first argument represents the
+providing \eqn{K \ge 1} predictions per row. Its first argument represents the
 model \code{object}, its second argument a data structure like \code{X}. Additional arguments
 (such as \code{type = "response"} in a GLM) can be passed via \code{...}. The default,
 \code{\link[stats:predict]{stats::predict()}}, will work in most cases. Note that column names in a resulting

--- a/man/perm_importance.Rd
+++ b/man/perm_importance.Rd
@@ -84,20 +84,22 @@ for instance \code{type = "response"} in a \code{\link[=glm]{glm()}} model.}
 
 \item{X}{A data.frame or matrix serving as background dataset.}
 
-\item{y}{Numeric vector or matrix of the response corresponding to \code{X}.}
+\item{y}{Vector/matrix of the response corresponding to \code{X}.}
 
 \item{pred_fun}{Prediction function of the form \verb{function(object, X, ...)},
-providing \eqn{K \ge 1} numeric predictions per row. Its first argument represents the
+providing \eqn{K \ge 1} predictions per row. Its first argument represents the
 model \code{object}, its second argument a data structure like \code{X}. Additional arguments
 (such as \code{type = "response"} in a GLM) can be passed via \code{...}. The default,
 \code{\link[stats:predict]{stats::predict()}}, will work in most cases. Note that column names in a resulting
 matrix of predictions will be used as default column names in the results.}
 
 \item{loss}{One of "squared_error", "logloss", "mlogloss", "poisson",
-"gamma", "absolute_error", or a loss function that turns observed and predicted
-values (vectors or matrices) into a vector or matrix of unit losses.
-For "mlogloss", the response \code{y} can either be a dummy matrix, or a vector with
-categories. The latter case is handled via \code{model.matrix(~ y + 0)}.}
+"gamma", "absolute_error", "classification_error". Alternatively, a loss function
+can be provided that turns observed and predicted values into a numeric vector or
+matrix of unit losses of the same length as \code{X}.
+For "mlogloss", the response \code{y} can either be a dummy matrix or a discrete vector.
+The latter case is handled via \code{model.matrix(~ y + 0)}.
+For "classification_error", both predictions and responses can be non-numeric.}
 
 \item{perms}{Number of permutations (default 4).}
 
@@ -164,7 +166,12 @@ situations. If there are K classes and n observations, the predictions form
 a (n x K) matrix of probabilities (with row-sums 1).
 The observed values \code{y} are either passed as (n x K) dummy matrix,
 or as discrete vector with corresponding levels.
-The latter case is turned into a dummy matrix via \code{model.matrix(~ y + 0)}
+The latter case is turned into a dummy matrix via \code{model.matrix(~ y + 0)}.
+\item "classification_error": Misclassification error. This is currently the
+only prespecified loss that accepts non-numeric predictions. Both the
+observed values \code{y} and the predictions can be character/factor. This
+loss function can be used in non-probabilistic classification settings.
+BUT: Probabilistic classification (with "mlogloss") is preferred.
 \item A function with signature \code{f(actual, predicted)}, returning a numeric
 vector of length n or a matrix with n rows, where n is the number of rows of \code{X}.
 }

--- a/man/perm_importance.Rd
+++ b/man/perm_importance.Rd
@@ -96,15 +96,14 @@ matrix of predictions will be used as default column names in the results.}
 \item{loss}{One of "squared_error", "logloss", "mlogloss", "poisson",
 "gamma", "absolute_error", or a loss function that turns observed and predicted
 values (vectors or matrices) into a vector or matrix of unit losses.
-For "mlogloss", the response \code{y} can either be a matrix with one column per category
-or a vector with categories. The latter case is internally exploded to the shape
-of the predictions via \code{stats::model.matrix(~ y + 0)}.}
+For "mlogloss", the response \code{y} can either be a dummy matrix, or a vector with
+categories. The latter case is handled via \code{model.matrix(~ y + 0)}.}
 
 \item{perms}{Number of permutations (default 4).}
 
 \item{agg_cols}{Should multivariate losses be summed up? Default is \code{FALSE}.}
 
-\item{normalize}{Should importance statistics be divided by performance?
+\item{normalize}{Should importance statistics be divided by average loss?
 Default is \code{FALSE}. If \code{TRUE}, an importance of 1 means that the average loss
 has doubled by shuffling that feature's column.}
 
@@ -118,7 +117,7 @@ selected from \code{X}. In this case, set a random seed for reproducibility.}
 \value{
 An object of class "perm_importance" containing these elements:
 \itemize{
-\item \code{imp}: (p x d) matrix containing the sorted importance values, i.e.,
+\item \code{imp}: (p x d) matrix containing the sorted (average) importance values, i.e.,
 a row per feature (group) and a column per loss dimension.
 \item \code{SE}: (p x d) matrix with corresponding standard errors of \code{imp}.
 Multiply with \code{sqrt(perms)} to get standard deviations.
@@ -128,14 +127,12 @@ Multiply with \code{sqrt(perms)} to get standard deviations.
 }
 \description{
 Calculates permutation feature importance (PVI) for a set of features or
-a set of feature groups.
+a set of feature groups \code{v}.
 }
 \details{
-The PVI of a feature is defined as the increase in average loss when
-shuffling the corresponding column before calculating predictions.
-The loss function can be specified as a string ("squared_error", "mlogloss", etc.)
-or a vector/matrix valued function. Note that the model is never refitted.
-Multivariate losses can be collapsed over columns (default) or analyzed separately.
+The PVI of a feature is defined as the increase in the average loss when
+shuffling the corresponding feature values before calculating predictions.
+By default, the process is repeated \code{perms = 4} times, and the results are averaged.
 }
 \section{Methods (by class)}{
 \itemize{
@@ -148,6 +145,31 @@ Multivariate losses can be collapsed over columns (default) or analyzed separate
 \item \code{perm_importance(explainer)}: Method for DALEX "explainer".
 
 }}
+\section{Losses}{
+
+
+The default \code{loss} is the "squared_error". Other choices:
+\itemize{
+\item "absolute_error": The absolute error is the loss corresponding to median regression.
+\item "poisson": Unit Poisson deviance, i.e., the loss function used in
+Poisson regression. Actual values \code{y} and predictions must be non-negative.
+\item "gamma": Unit gamma deviance, i.e., the loss function of Gamma regression.
+Actual values \code{y} and predictions must be positive.
+\item "logloss": The Log Loss is the loss function used in logistic regression,
+and the top choice in probabilistic binary classification. Responses \code{y} and
+predictions must be between 0 and 1. Predictions represent probabilities of
+having a "1".
+\item "mlogloss": Multi-Log-Loss is the natural loss function in probabilistic multi-class
+situations. If there are K classes and n observations, the predictions form
+a (n x K) matrix of probabilities (with row-sums 1).
+The observed values \code{y} are either passed as (n x K) dummy matrix,
+or as discrete vector with corresponding levels.
+The latter case is turned into a dummy matrix via \code{model.matrix(~ y + 0)}
+\item A function with signature \code{f(actual, predicted)}, returning a numeric
+vector of length n or a matrix with n rows, where n is the number of rows of \code{X}.
+}
+}
+
 \examples{
 # MODEL 1: Linear regression
 fit <- lm(Sepal.Length ~ ., data = iris)

--- a/tests/testthat/test_average_loss.R
+++ b/tests/testthat/test_average_loss.R
@@ -38,6 +38,28 @@ test_that("average_loss() works with weights and grouped", {
   expect_false(identical(s2, s3))
 })
 
+test_that("average_loss() can work with non-numeric predictions", {
+  pf <- function(m, X) rep("setosa", times = nrow(X))
+  expect_warning(average_loss(1, X = iris, y = iris$Species, pred_fun = pf))
+  expect_equal(
+    c(average_loss(
+      1, X = iris, y = iris$Species, pred_fun = pf, loss = "classification_error"
+    )),
+    2/3
+  )
+  expect_equal(
+    c(average_loss(
+      1, 
+      X = iris, 
+      y = iris$Species, 
+      pred_fun = pf, 
+      loss = "classification_error",
+      BY = iris$Species
+    )),
+    c(0, 1, 1)
+  )
+})
+
 #================================================
 # Multivariate model
 #================================================

--- a/tests/testthat/test_losses.R
+++ b/tests/testthat/test_losses.R
@@ -16,6 +16,12 @@ test_that("loss_absolute_error() works for specific case", {
   expect_equal(loss_absolute_error(y, p), abs(y - p))
 })
 
+test_that("loss_classification_error() works for specific case", {
+  y <- iris$Species
+  p <- rev(iris$Species)
+  expect_equal(loss_classification_error(y, p), 0 + (y != p))
+})
+
 test_that("loss_mlogloss() is consistent with loss_logloss()", {
   y <- 0:1
   p <- c(0.1, 0.8)

--- a/tests/testthat/test_perm_importance.R
+++ b/tests/testthat/test_perm_importance.R
@@ -97,6 +97,20 @@ test_that("matrix case works as well", {
   )
 })
 
+test_that("non-numeric predictions can work as well", {
+  expect_equal(
+    c(perm_importance(
+      1, 
+      v = "Sepal.Length", 
+      X = iris, 
+      y = iris$Species, 
+      pred_fun = function(m, X) rep("setosa", times = nrow(X)), 
+      loss = "classification_error"
+    )$imp),
+    0
+  )
+})
+
 #================================================
 # Multivariate model
 #================================================


### PR DESCRIPTION
- Documentation of losses
- Allow average_loss() and perm_importance() to work with non-numeric predictions
- Adding loss_classification_error() to loss functions