### PR TITLE
Moving statistics calculations to hstats()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Grid calculation: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid. This affects `ice()`, `partial_dep()` and the exported helper functions `univariate_grid()` and `multivariate_grid()`.
 
+## Internal major changes
+
+- All available H-statistics are now calculated within `hstats()` and attached to the resulting object. Each statistic is stored as list with numerator and denominator matrices/vectors. The functions `h2()`, `h2_overall()`, `h2_pairwise()`, and `h2_threeway()`, `print.hstats()`, `summary().hstats()`, `plot.hstats()` will use these without having to recalculate the required numerators and denominators. The results, however, are unchanged.
+
 ## Bug fixes
 
 - All progress bars were initialized 1 step too late. This has been fixed.

--- a/R/H2.R
+++ b/R/H2.R
@@ -67,11 +67,28 @@ h2.default <- function(object, ...) {
 #' @export
 h2.hstats <- function(object, normalize = TRUE, squared = TRUE, eps = 1e-8, ...) {
   postprocess(
-    num = with(object, wcolMeans((f - Reduce("+", F_j))^2, w = w)),
-    denom = object[["mean_f2"]],
+    num = object$h2$num,
+    denom = object$h2$denom,
     normalize = normalize, 
     squared = squared, 
     sort = FALSE, 
     eps = eps
   )
 }
+
+#' Raw H2
+#' 
+#' Internal helper function that calculates numerator and denominator of
+#' statistic in title.
+#' 
+#' @noRd
+#' @keywords internal
+#' @param x A list containing the elements "f", "F_j", "w", and "mean_f2".
+#' @returns A list with the numerator and denominator statistics.
+h2_raw <- function(x) {
+  list(
+    num = with(x, wcolMeans((f - Reduce("+", F_j))^2, w = w)), 
+    denom = x[["mean_f2"]]
+  )
+}
+

--- a/R/H2_overall.R
+++ b/R/H2_overall.R
@@ -80,15 +80,10 @@ h2_overall.default <- function(object, ...) {
 h2_overall.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
                               top_m = 15L, eps = 1e-8, plot = FALSE, fill = "#2b51a1", 
                               ...) {
-  num <- with(
-    object, matrix(nrow = length(v), ncol = K, dimnames = list(v, pred_names))
-  )
-  for (z in object[["v"]]) {
-    num[z, ] <- with(object, wcolMeans((f - F_j[[z]] - F_not_j[[z]])^2, w = w))
-  }
+  s <- object$h2_overall
   out <- postprocess(
-    num = num,
-    denom = object[["mean_f2"]],
+    num = s$num,
+    denom = s$denom,
     normalize = normalize, 
     squared = squared, 
     sort = sort, 
@@ -96,4 +91,26 @@ h2_overall.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = T
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out
+}
+
+# Helper function
+
+#' Raw H2 Overall
+#' 
+#' Internal helper function that calculates numerator and denominator of
+#' statistic in title.
+#' 
+#' @noRd
+#' @keywords internal
+#' @param x A list containing the elements "v", "K", "pred_names", 
+#'   "f", "F_not_j", "F_j", "mean_f2", and "w".
+#' @returns A list with the numerator and denominator statistics.
+h2_overall_raw <- function(x) {
+  num <- with(x, matrix(nrow = length(v), ncol = K, dimnames = list(v, pred_names)))
+  
+  for (z in x[["v"]]) {
+    num[z, ] <- with(x, wcolMeans((f - F_j[[z]] - F_not_j[[z]])^2, w = w))
+  }
+  
+  list(num = num, denom = x[["mean_f2"]])
 }

--- a/R/H2_pairwise.R
+++ b/R/H2_pairwise.R
@@ -84,30 +84,13 @@ h2_pairwise.default <- function(object, ...) {
 h2_pairwise.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
                                top_m = 15L, eps = 1e-8, plot = FALSE, 
                                fill = "#2b51a1", ...) {
-  combs <- object[["combs2"]]
-  
-  if (is.null(combs)) {
+  s <- object$h2_pairwise
+  if (is.null(s)) {
     return(NULL)
   }
-  
-  # Note that F_jk are in the same order as combs
-  num <- denom <- with(
-    object,
-    matrix(
-      nrow = length(combs), ncol = K, dimnames = list(names(combs), pred_names)
-    )
-  )
-  
-  for (i in seq_along(combs)) {
-    z <- combs[[i]]
-    num[i, ] <- with(
-      object, wcolMeans((F_jk[[i]] - F_j[[z[1L]]] - F_j[[z[2L]]])^2, w = w)
-    )
-    denom[i, ] <- if (normalize) with(object, wcolMeans(F_jk[[i]]^2, w = w)) else 1
-  }
   out <- postprocess(
-    num = num,
-    denom = denom,
+    num = s$num,
+    denom = s$denom,
     normalize = normalize, 
     squared = squared, 
     sort = sort, 
@@ -115,4 +98,31 @@ h2_pairwise.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = 
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out
+}
+
+#' Raw H2 Pairwise
+#' 
+#' Internal helper function that calculates numerator and denominator of
+#' statistic in title.
+#' 
+#' @noRd
+#' @keywords internal
+#' @param x A list containing the elements "combs2", "K", "pred_names", 
+#'   "F_jk", "F_j", and "w".
+#' @returns A list with the numerator and denominator statistics.
+h2_pairwise_raw <- function(x) {
+  combs <- x[["combs2"]]
+  
+  # Note that F_jk are in the same order as combs
+  num <- denom <- with(
+    x, matrix(nrow = length(combs), ncol = K, dimnames = list(names(combs), pred_names))
+  )
+  
+  for (i in seq_along(combs)) {
+    z <- combs[[i]]
+    num[i, ] <- with(x, wcolMeans((F_jk[[i]] - F_j[[z[1L]]] - F_j[[z[2L]]])^2, w = w))
+    denom[i, ] <- with(x, wcolMeans(F_jk[[i]]^2, w = w))
+  }
+  
+  list(num = num, denom = denom)
 }

--- a/R/hstats.R
+++ b/R/hstats.R
@@ -62,21 +62,21 @@
 #'   - `v_pairwise`: Subset of `v` with largest `h2_overall()` used for pairwise 
 #'     calculations.
 #'   - `combs2`: Named list of variable pairs for which pairwise partial 
-#'     dependence functions are available. Only if pairwise calculations are done.
+#'     dependence functions are available. Only if pairwise calculations have been done.
 #'   - `F_jk`: List of matrices, each representing (centered) bivariate 
 #'     partial dependence functions \eqn{F_{jk}}. 
-#'     Only if pairwise calculations are done.
+#'     Only if pairwise calculations have been done.
 #'   - `h2_pairwise`: List with numerator and denominator of \eqn{H^2_{jk}}.
-#'     Only if pairwise calculations are done.
+#'     Only if pairwise calculations have been done.
 #'   - `v_threeway`: Subset of `v` with largest `h2_overall()` used for three-way 
 #'     calculations.
 #'   - `combs3`: Named list of variable triples for which three-way partial 
-#'     dependence functions are available. Only if threeway calculations are done.
+#'     dependence functions are available. Only if threeway calculations have been done.
 #'   - `F_jkl`: List of matrices, each representing (centered) three-way 
 #'     partial dependence functions \eqn{F_{jkl}}. 
-#'     Only if threeway calculations are done.
+#'     Only if threeway calculations have been done.
 #'   - `h2_threeway`: List with numerator and denominator of \eqn{H^2_{jkl}}.
-#'     Only if threeway calculations are done.
+#'     Only if threeway calculations have been done.
 #' @references
 #'   Friedman, Jerome H., and Bogdan E. Popescu. *"Predictive Learning via Rule Ensembles."*
 #'     The Annals of Applied Statistics 2, no. 3 (2008): 916-54.

--- a/man/hstats.Rd
+++ b/man/hstats.Rd
@@ -110,18 +110,26 @@ partial dependence functions \eqn{F_j}.
 functions \eqn{F_{\setminus j}} of other features.
 \item \code{K}: Number of columns of prediction matrix.
 \item \code{pred_names}: Column names of prediction matrix.
+\item \code{h2}: List with numerator and denominator of \eqn{H^2}.
+\item \code{h2_overall}: List with numerator and denominator of \eqn{H^2_j}.
 \item \code{v_pairwise}: Subset of \code{v} with largest \code{h2_overall()} used for pairwise
 calculations.
 \item \code{combs2}: Named list of variable pairs for which pairwise partial
-dependence functions are available.
+dependence functions are available. Only if pairwise calculations are done.
 \item \code{F_jk}: List of matrices, each representing (centered) bivariate
 partial dependence functions \eqn{F_{jk}}.
+Only if pairwise calculations are done.
+\item \code{h2_pairwise}: List with numerator and denominator of \eqn{H^2_{jk}}.
+Only if pairwise calculations are done.
 \item \code{v_threeway}: Subset of \code{v} with largest \code{h2_overall()} used for three-way
 calculations.
 \item \code{combs3}: Named list of variable triples for which three-way partial
-dependence functions are available.
+dependence functions are available. Only if threeway calculations are done.
 \item \code{F_jkl}: List of matrices, each representing (centered) three-way
 partial dependence functions \eqn{F_{jkl}}.
+Only if threeway calculations are done.
+\item \code{h2_threeway}: List with numerator and denominator of \eqn{H^2_{jkl}}.
+Only if threeway calculations are done.
 }
 }
 \description{

--- a/man/hstats.Rd
+++ b/man/hstats.Rd
@@ -115,21 +115,21 @@ functions \eqn{F_{\setminus j}} of other features.
 \item \code{v_pairwise}: Subset of \code{v} with largest \code{h2_overall()} used for pairwise
 calculations.
 \item \code{combs2}: Named list of variable pairs for which pairwise partial
-dependence functions are available. Only if pairwise calculations are done.
+dependence functions are available. Only if pairwise calculations have been done.
 \item \code{F_jk}: List of matrices, each representing (centered) bivariate
 partial dependence functions \eqn{F_{jk}}.
-Only if pairwise calculations are done.
+Only if pairwise calculations have been done.
 \item \code{h2_pairwise}: List with numerator and denominator of \eqn{H^2_{jk}}.
-Only if pairwise calculations are done.
+Only if pairwise calculations have been done.
 \item \code{v_threeway}: Subset of \code{v} with largest \code{h2_overall()} used for three-way
 calculations.
 \item \code{combs3}: Named list of variable triples for which three-way partial
-dependence functions are available. Only if threeway calculations are done.
+dependence functions are available. Only if threeway calculations have been done.
 \item \code{F_jkl}: List of matrices, each representing (centered) three-way
 partial dependence functions \eqn{F_{jkl}}.
-Only if threeway calculations are done.
+Only if threeway calculations have been done.
 \item \code{h2_threeway}: List with numerator and denominator of \eqn{H^2_{jkl}}.
-Only if threeway calculations are done.
+Only if threeway calculations have been done.
 }
 }
 \description{

--- a/tests/testthat/test_hstats.R
+++ b/tests/testthat/test_hstats.R
@@ -147,6 +147,15 @@ test_that("Three-way interaction is positive in model with such terms", {
   expect_true(h2_threeway(s) > 0)
 })
 
+test_that("Three-way interaction behaves correctly across dimensions", {
+  fit <- lm(cbind(up = uptake, up2 = 2 * uptake) ~ Type * Treatment * conc, data = CO2)
+  s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
+  out <- h2_threeway(s)
+  expect_equal(out[, "up"], out[, "up2"])
+  out <- h2_threeway(s, squared = FALSE, normalize = FALSE)
+  expect_equal(2 * out[, "up"], out[, "up2"])
+})
+
 test_that("Three-way interaction can be suppressed", {
   fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
   s <- hstats(fit, X = CO2[2:4], verbose = FALSE, threeway_m = 0L)
@@ -157,41 +166,37 @@ test_that("Three-way interaction can be suppressed", {
   expect_null(h2_threeway(s))
 })
 
-test_that("Three-way interaction behaves correctly across dimensions", {
-  fit <- lm(cbind(up = uptake, up2 = 2 * uptake) ~ Type * Treatment * conc, data = CO2)
-  s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
-  out <- h2_threeway(s)
-  expect_equal(out[, "up"], out[, "up2"])
-  out <- h2_threeway(s, squared = FALSE, normalize = FALSE)
-  expect_equal(2 * out[, "up"], out[, "up2"])
-})
+fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
+s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
 
-test_that("Statistics react on normalize", {
-  fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
-  s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
+test_that("Statistics react on normalize and squaring", {
+  expect_identical(h2(s), s$h2$num / s$h2$denom)
+  expect_identical(h2(s, normalize = FALSE), s$h2$num)
+  expect_identical(h2(s, normalize = FALSE, squared = FALSE), sqrt(s$h2$num))
   
-  expect_false(identical(h2(s), h2(s, normalize = FALSE)))
-  expect_false(identical(h2_overall(s), h2_overall(s, normalize = FALSE)))
-  expect_false(identical(h2_pairwise(s), h2_pairwise(s, normalize = FALSE)))
-  expect_false(identical(h2_threeway(s), h2_threeway(s, normalize = FALSE)))
-  expect_false(identical(summary(s), summary(s, normalize = FALSE)))
-})
-
-test_that("Statistics react on squared", {
-  fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
-  s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
+  expect_identical(h2_overall(s), s$h2_overall$num / s$h2_overall$denom)
+  expect_identical(h2_overall(s, normalize = FALSE), s$h2_overall$num)
+  expect_identical(
+    h2_overall(s, normalize = FALSE, squared = FALSE), 
+    sqrt(s$h2_overall$num)
+  )
   
-  expect_false(identical(h2(s), h2(s, squared = FALSE)))
-  expect_false(identical(h2_overall(s), h2_overall(s, squared = FALSE)))
-  expect_false(identical(h2_pairwise(s), h2_pairwise(s, squared = FALSE)))
-  expect_false(identical(h2_threeway(s), h2_threeway(s, squared = FALSE)))
-  expect_false(identical(summary(s), summary(s, squared = FALSE)))
+  expect_identical(h2_pairwise(s), s$h2_pairwise$num / s$h2_pairwise$denom)
+  expect_identical(h2_pairwise(s, normalize = FALSE), s$h2_pairwise$num)
+  expect_identical(
+    h2_pairwise(s, normalize = FALSE, squared = FALSE), 
+    sqrt(s$h2_pairwise$num)
+  )
+  
+  expect_identical(h2_threeway(s), s$h2_threeway$num / s$h2_threeway$denom)
+  expect_identical(h2_threeway(s, normalize = FALSE), s$h2_threeway$num)
+  expect_identical(
+    h2_threeway(s, normalize = FALSE, squared = FALSE), 
+    sqrt(s$h2_threeway$num)
+  )
 })
 
 test_that("Statistics are sorted", {
-  fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
-  s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
-  
   expect_false(is.unsorted(-h2_overall(s)))
   expect_false(is.unsorted(-h2_pairwise(s)))
 })

--- a/tests/testthat/test_hstats.R
+++ b/tests/testthat/test_hstats.R
@@ -147,6 +147,16 @@ test_that("Three-way interaction is positive in model with such terms", {
   expect_true(h2_threeway(s) > 0)
 })
 
+test_that("Three-way interaction can be suppressed", {
+  fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
+  s <- hstats(fit, X = CO2[2:4], verbose = FALSE, threeway_m = 0L)
+  expect_null(h2_threeway(s))
+  
+  s <- hstats(fit, X = CO2[2:4], verbose = FALSE, pairwise_m = 0L)
+  expect_null(h2_pairwise(s))
+  expect_null(h2_threeway(s))
+})
+
 test_that("Three-way interaction behaves correctly across dimensions", {
   fit <- lm(cbind(up = uptake, up2 = 2 * uptake) ~ Type * Treatment * conc, data = CO2)
   s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
@@ -154,6 +164,34 @@ test_that("Three-way interaction behaves correctly across dimensions", {
   expect_equal(out[, "up"], out[, "up2"])
   out <- h2_threeway(s, squared = FALSE, normalize = FALSE)
   expect_equal(2 * out[, "up"], out[, "up2"])
+})
+
+test_that("Statistics react on normalize", {
+  fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
+  s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
+  
+  expect_false(identical(h2(s), h2(s, normalize = FALSE)))
+  expect_false(identical(h2_overall(s), h2_overall(s, normalize = FALSE)))
+  expect_false(identical(h2_pairwise(s), h2_pairwise(s, normalize = FALSE)))
+  expect_false(identical(h2_threeway(s), h2_threeway(s, normalize = FALSE)))
+})
+
+test_that("Statistics react on squared", {
+  fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
+  s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
+  
+  expect_false(identical(h2(s), h2(s, squared = FALSE)))
+  expect_false(identical(h2_overall(s), h2_overall(s, squared = FALSE)))
+  expect_false(identical(h2_pairwise(s), h2_pairwise(s, squared = FALSE)))
+  expect_false(identical(h2_threeway(s), h2_threeway(s, squared = FALSE)))
+})
+
+test_that("Statistics are sorted", {
+  fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
+  s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
+  
+  expect_false(is.unsorted(-h2_overall(s)))
+  expect_false(is.unsorted(-h2_pairwise(s)))
 })
 
 test_that("get_v() works", {

--- a/tests/testthat/test_hstats.R
+++ b/tests/testthat/test_hstats.R
@@ -174,6 +174,7 @@ test_that("Statistics react on normalize", {
   expect_false(identical(h2_overall(s), h2_overall(s, normalize = FALSE)))
   expect_false(identical(h2_pairwise(s), h2_pairwise(s, normalize = FALSE)))
   expect_false(identical(h2_threeway(s), h2_threeway(s, normalize = FALSE)))
+  expect_false(identical(summary(s), summary(s, normalize = FALSE)))
 })
 
 test_that("Statistics react on squared", {
@@ -184,6 +185,7 @@ test_that("Statistics react on squared", {
   expect_false(identical(h2_overall(s), h2_overall(s, squared = FALSE)))
   expect_false(identical(h2_pairwise(s), h2_pairwise(s, squared = FALSE)))
   expect_false(identical(h2_threeway(s), h2_threeway(s, squared = FALSE)))
+  expect_false(identical(summary(s), summary(s, squared = FALSE)))
 })
 
 test_that("Statistics are sorted", {

--- a/tests/testthat/test_hstats.R
+++ b/tests/testthat/test_hstats.R
@@ -169,23 +169,31 @@ test_that("Three-way interaction can be suppressed", {
 fit <- lm(uptake ~ Type * Treatment * conc, data = CO2)
 s <- hstats(fit, X = CO2[2:4], verbose = FALSE)
 
-test_that("Statistics react on normalize and squaring", {
+test_that("Statistics react on normalize, (sorting), squaring, and top m", {
   expect_identical(h2(s), s$h2$num / s$h2$denom)
   expect_identical(h2(s, normalize = FALSE), s$h2$num)
   expect_identical(h2(s, normalize = FALSE, squared = FALSE), sqrt(s$h2$num))
   
-  expect_identical(h2_overall(s), s$h2_overall$num / s$h2_overall$denom)
-  expect_identical(h2_overall(s, normalize = FALSE), s$h2_overall$num)
+  expect_identical(h2_overall(s, sort = FALSE), s$h2_overall$num / s$h2_overall$denom)
+  expect_identical(h2_overall(s, sort = FALSE, normalize = FALSE), s$h2_overall$num)
   expect_identical(
-    h2_overall(s, normalize = FALSE, squared = FALSE), 
+    h2_overall(s, sort = FALSE, normalize = FALSE, squared = FALSE), 
     sqrt(s$h2_overall$num)
   )
-  
-  expect_identical(h2_pairwise(s), s$h2_pairwise$num / s$h2_pairwise$denom)
-  expect_identical(h2_pairwise(s, normalize = FALSE), s$h2_pairwise$num)
   expect_identical(
-    h2_pairwise(s, normalize = FALSE, squared = FALSE), 
+    h2_overall(s, sort = FALSE, top_m = 2L, normalize = FALSE), 
+    s$h2_overall$num[1:2, , drop = FALSE]
+  )
+  
+  expect_identical(h2_pairwise(s, sort = FALSE), s$h2_pairwise$num / s$h2_pairwise$denom)
+  expect_identical(h2_pairwise(s, sort = FALSE, normalize = FALSE), s$h2_pairwise$num)
+  expect_identical(
+    h2_pairwise(s, sort = FALSE, normalize = FALSE, squared = FALSE), 
     sqrt(s$h2_pairwise$num)
+  )
+  expect_identical(
+    h2_pairwise(s, sort = FALSE, top_m = 2L, normalize = FALSE), 
+    s$h2_pairwise$num[1:2, , drop = FALSE]
   )
   
   expect_identical(h2_threeway(s), s$h2_threeway$num / s$h2_threeway$denom)
@@ -199,6 +207,20 @@ test_that("Statistics react on normalize and squaring", {
 test_that("Statistics are sorted", {
   expect_false(is.unsorted(-h2_overall(s)))
   expect_false(is.unsorted(-h2_pairwise(s)))
+})
+
+test_that("summary() reacts on normalize and squared", {
+  su <- summary(s, normalize = FALSE)
+  expect_identical(su$h2, h2(s, normalize = FALSE))
+  expect_identical(su$h2_overall, h2_overall(s, normalize = FALSE))
+  expect_identical(su$h2_pairwise, h2_pairwise(s, normalize = FALSE))
+  expect_identical(su$h2_threeway, h2_threeway(s, normalize = FALSE))
+  
+  su <- summary(s, squared = FALSE)
+  expect_identical(su$h2, h2(s, squared = FALSE))
+  expect_identical(su$h2_overall, h2_overall(s, squared = FALSE))
+  expect_identical(su$h2_pairwise, h2_pairwise(s, squared = FALSE))
+  expect_identical(su$h2_threeway, h2_threeway(s, squared = FALSE))
 })
 
 test_that("get_v() works", {


### PR DESCRIPTION
The aim of this PR is to move the calculation of H-statistics into `hstats()`. This is different from the current implementation where the functions `h2()`, ... would take an "hstats" object and do the cheap calculations themselfes. These functions should only care about postprocessing, like "take square?", "normalize", etc.