### PR TITLE
Simplify the multivariate case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,14 @@
 
 - All available H-statistics are now calculated within `hstats()` and attached to the resulting object. Each statistic is stored as list with numerator and denominator matrices/vectors. The functions `h2()`, `h2_overall()`, `h2_pairwise()`, and `h2_threeway()`, `print.hstats()`, `summary().hstats()`, `plot.hstats()` will use these without having to recalculate the required numerators and denominators. The results, however, are unchanged.
 
+## Minor improvements
+
+- `perm_importance()` and `average_loss()` will now recycle a univariate response when combined with multivariate predictions. This is useful, e.g., when the prediction function represents the predictions of multiple models that should be evaluated against a common response.
+
 ## Bug fixes
 
-- All progress bars were initialized 1 step too late. This has been fixed.
+- All progress bars were initialized 1 step too late.
+- `perm_importance()` and `average_loss()` would fail for "mlogloss" in case the response `y` was univariate *and* non-factor/non-character.
 
 # hstats 0.2.0
 

--- a/R/average_loss.R
+++ b/R/average_loss.R
@@ -20,14 +20,15 @@
 #'   a (n x K) matrix of probabilities (with row-sums 1).
 #'   The observed values `y` are either passed as (n x K) dummy matrix, 
 #'   or as discrete vector with corresponding levels. 
-#'   The latter case is turned into a dummy matrix via `model.matrix(~ y + 0)`.
-#' - "classification_error": Misclassification error. This is currently the
-#'   only prespecified loss that accepts non-numeric predictions. Both the 
+#'   The latter case is turned into a dummy matrix via 
+#'   `model.matrix(~ as.factor(y) + 0)`.
+#' - "classification_error": Misclassification error. Both the 
 #'   observed values `y` and the predictions can be character/factor. This
 #'   loss function can be used in non-probabilistic classification settings.
-#'   BUT: Probabilistic classification (with "mlogloss") is preferred.
+#'   BUT: Probabilistic classification (with "mlogloss") is clearly preferred in most
+#'   situations.
 #' - A function with signature `f(actual, predicted)`, returning a numeric 
-#'   vector of length n or a matrix with n rows, where n is the number of rows of `X`.
+#'   vector or matrix of the same length as the input.
 #'
 #' @inheritParams hstats
 #' @param y Vector/matrix of the response corresponding to `X`.
@@ -36,7 +37,7 @@
 #'   can be provided that turns observed and predicted values into a numeric vector or 
 #'   matrix of unit losses of the same length as `X`.
 #'   For "mlogloss", the response `y` can either be a dummy matrix or a discrete vector. 
-#'   The latter case is handled via `model.matrix(~ y + 0)`.
+#'   The latter case is handled via `model.matrix(~ as.factor(y) + 0)`.
 #'   For "classification_error", both predictions and responses can be non-numeric.
 #' @param BY Optional grouping vector.
 #' @returns A matrix with one row per group and one column per loss dimension.
@@ -73,9 +74,6 @@ average_loss.default <- function(object, X, y,
       is.vector(BY) || is.factor(BY),
       length(BY) == nrow(X)
     )
-  }
-  if (!is.function(loss) && loss == "mlogloss" && NCOL(y) == 1L) {
-    y <- stats::model.matrix(~y + 0)
   }
   if (!is.function(loss)) {
     loss <- get_loss_fun(loss)

--- a/R/losses.R
+++ b/R/losses.R
@@ -9,7 +9,7 @@
 #' @param predicted A numeric vector/matrix.
 #' @returns Vector or matrix of numeric losses.
 loss_squared_error <- function(actual, predicted) {
-  check_dim(actual = actual, predicted = predicted)
+  actual <- expand_actual(actual = actual, predicted = predicted)
   (actual - predicted)^2
 }
 
@@ -24,7 +24,7 @@ loss_squared_error <- function(actual, predicted) {
 #' @param predicted A numeric vector/matrix.
 #' @returns Vector or matrix of numeric losses.
 loss_absolute_error <- function(actual, predicted) {
-  check_dim(actual = actual, predicted = predicted)
+  actual <- expand_actual(actual = actual, predicted = predicted)
   abs(actual - predicted)
 }
 
@@ -39,7 +39,7 @@ loss_absolute_error <- function(actual, predicted) {
 #' @param predicted A numeric vector/matrix with non-negative values.
 #' @returns Vector or matrix of numeric losses.
 loss_poisson <- function(actual, predicted) {
-  check_dim(actual = actual, predicted = predicted)
+  actual <- expand_actual(actual = actual, predicted = predicted)
   stopifnot(
     all(predicted >= 0),
     all(actual >= 0)
@@ -61,7 +61,7 @@ loss_poisson <- function(actual, predicted) {
 #' @param predicted A numeric vector/matrix with positive values.
 #' @returns Vector or matrix of numeric losses.
 loss_gamma <- function(actual, predicted) {
-  check_dim(actual = actual, predicted = predicted)
+  actual <- expand_actual(actual = actual, predicted = predicted)
   stopifnot(
     all(predicted > 0), 
     all(actual > 0)
@@ -76,11 +76,11 @@ loss_gamma <- function(actual, predicted) {
 #' @noRd
 #' @keywords internal
 #'
-#' @param actual A vector/matrix with discrete values.
-#' @param predicted A vector/matrix with discrete values.
+#' @param actual A vector/factor/matrix with discrete values.
+#' @param predicted A vector/factor/matrix with discrete values.
 #' @returns Vector or matrix of numeric losses.
 loss_classification_error <- function(actual, predicted) {
-  check_dim(actual = actual, predicted = predicted)
+  actual <- expand_actual(actual = actual, predicted = predicted)
   (actual != predicted) * 1.0
 }
 
@@ -96,7 +96,7 @@ loss_classification_error <- function(actual, predicted) {
 #' @param predicted A numeric vector/matrix with values between 0 and 1.
 #' @returns Vector or matrix of numeric losses.
 loss_logloss <- function(actual, predicted) {
-  check_dim(actual = actual, predicted = predicted)
+  actual <- expand_actual(actual = actual, predicted = predicted)
   stopifnot(
     all(predicted >= 0), 
     all(predicted <= 1),
@@ -114,36 +114,53 @@ loss_logloss <- function(actual, predicted) {
 #' @noRd
 #' @keywords internal
 #'
-#' @param actual A numeric vector/matrix with values between 0 and 1.
-#' @param predicted A numeric vector/matrix with values between 0 and 1.
+#' @param actual A numeric matrix with values between 0 and 1, or a 
+#'   discrete vector that will be one-hot-encoded via 
+#'   `model.matrix(~ as.factor(actual) + 0)`.
+#'   The column order of `predicted` must be in line with this!
+#' @param predicted A numeric matrix with values between 0 and 1.
 #' @returns `TRUE` (or an error message).
 loss_mlogloss <- function(actual, predicted) {
-  check_dim(actual = actual, predicted = predicted)
+  if (NCOL(actual) == 1L && NCOL(predicted) > 1L) {
+    actual <- stats::model.matrix(~ as.factor(actual) + 0)
+  }
   stopifnot(
+    NCOL(actual) == NCOL(predicted),
     all(predicted >= 0), 
     all(predicted <= 1),
     all(actual >= 0),
     all(actual <= 1)
   )
-  -rowSums(xlogy(actual, predicted))
+  unname(-rowSums(xlogy(actual, predicted)))
 }
 
-#' Consistency Check on Dimensions
+#' Expands 1D actual to NCOL(predicted)
 #' 
-#' Internal function. Checks if the number of columns of the two inputs are identical.
+#' Internal function. Checks consistency of column counts. If `NCOL(actual) == 1`
+#' and `NCOL(predicted) > 1`, replicates `actual` into a matrix.
 #' 
 #' @noRd
 #' @keywords internal
 #'
-#' @param actual A numeric vector/matrix.
-#' @param predicted A numeric vector/matrix.
-#' @returns `TRUE` (or an error message).
-check_dim <- function(actual, predicted) {
-  stopifnot(
-    # NROW(actual) == NROW(predicted),
-    NCOL(actual) == NCOL(predicted)
-  )
-  TRUE
+#' @param actual A vector/matrix/data.frame.
+#' @param predicted A vector/matrix/data.frame.
+#' @returns A matrix.
+expand_actual <- function(actual, predicted) {
+  pp <- NCOL(predicted)
+  pa <- NCOL(actual)
+  if (pa == pp) {
+    return(actual)
+  }
+  if (pp > 1L && pa == 1L) {
+    if (is.data.frame(actual)) {
+      actual <- as.matrix(actual)
+    }
+    actual <- matrix(actual, nrow = NROW(actual), ncol = pp, byrow = FALSE)
+    colnames(actual) <- colnames(predicted)
+  } else {
+    stop("NCOL(actual) should be identical to NCOL(predicted), or equal to 1")
+  }
+  return(actual)
 }
 
 #' Calculates x*log(y)

--- a/R/losses.R
+++ b/R/losses.R
@@ -148,7 +148,7 @@ check_dim <- function(actual, predicted) {
 
 #' Calculates x*log(y)
 #' 
-#' Internal function.
+#' Internal function. Returns 0 whenever x = 0 and y >= 0.
 #' 
 #' @noRd
 #' @keywords internal
@@ -157,10 +157,9 @@ check_dim <- function(actual, predicted) {
 #' @param y A numeric vector/matrix.
 #' @returns A numeric vector or matrix.
 xlogy <- function(x, y) {
-  out <- x
-  p <- x != 0
-  out[p] <- x[p] * log(y[p])
-  out
+  out <- x * log(y)
+  out[x == 0] <- 0
+  return(out)
 }
 
 #' String to function

--- a/R/perm_importance.R
+++ b/R/perm_importance.R
@@ -72,9 +72,6 @@ perm_importance.default <- function(object, X, y, v = colnames(X),
     pred_fun = pred_fun, 
     w = w
   )
-  if (!is.function(loss) && loss == "mlogloss" && NCOL(y) == 1L) {
-    y <- stats::model.matrix(~y + 0)
-  }
   stopifnot(
     NROW(y) == nrow(X),
     perms >= 1L

--- a/R/utils.R
+++ b/R/utils.R
@@ -35,7 +35,6 @@ wrowmean <- function(x, ngroups = 1L, w = NULL) {
   if (ngroups == 1L) {
     return(rbind(wcolMeans(x, w = w)))
   }
-  p <- NCOL(x)
   n_bg <- NROW(x) %/% ngroups
   g <- rep(seq_len(ngroups), each = n_bg)
   # Even faster: cbind(collapse::fmean(x, g = g, w = w))

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ library(ggplot2)
 
 set.seed(1)
 fit <- ranger(Species ~ ., data = iris, probability = TRUE)
-average_loss(fit, X = iris, y = iris$Species, loss = "mlogloss")  # 0.054
+average_loss(fit, X = iris, y = iris$Species, loss = "mlogloss")  # 0.0521
 
 s <- hstats(fit, X = iris[-5])
 s

--- a/man/average_loss.Rd
+++ b/man/average_loss.Rd
@@ -79,7 +79,7 @@ matrix of predictions will be used as default column names in the results.}
 can be provided that turns observed and predicted values into a numeric vector or
 matrix of unit losses of the same length as \code{X}.
 For "mlogloss", the response \code{y} can either be a dummy matrix or a discrete vector.
-The latter case is handled via \code{model.matrix(~ y + 0)}.
+The latter case is handled via \code{model.matrix(~ as.factor(y) + 0)}.
 For "classification_error", both predictions and responses can be non-numeric.}
 
 \item{w}{Optional vector of case weights for each row of \code{X}.}
@@ -123,14 +123,15 @@ situations. If there are K classes and n observations, the predictions form
 a (n x K) matrix of probabilities (with row-sums 1).
 The observed values \code{y} are either passed as (n x K) dummy matrix,
 or as discrete vector with corresponding levels.
-The latter case is turned into a dummy matrix via \code{model.matrix(~ y + 0)}.
-\item "classification_error": Misclassification error. This is currently the
-only prespecified loss that accepts non-numeric predictions. Both the
+The latter case is turned into a dummy matrix via
+\code{model.matrix(~ as.factor(y) + 0)}.
+\item "classification_error": Misclassification error. Both the
 observed values \code{y} and the predictions can be character/factor. This
 loss function can be used in non-probabilistic classification settings.
-BUT: Probabilistic classification (with "mlogloss") is preferred.
+BUT: Probabilistic classification (with "mlogloss") is clearly preferred in most
+situations.
 \item A function with signature \code{f(actual, predicted)}, returning a numeric
-vector of length n or a matrix with n rows, where n is the number of rows of \code{X}.
+vector or matrix of the same length as the input.
 }
 }
 

--- a/man/perm_importance.Rd
+++ b/man/perm_importance.Rd
@@ -98,7 +98,7 @@ matrix of predictions will be used as default column names in the results.}
 can be provided that turns observed and predicted values into a numeric vector or
 matrix of unit losses of the same length as \code{X}.
 For "mlogloss", the response \code{y} can either be a dummy matrix or a discrete vector.
-The latter case is handled via \code{model.matrix(~ y + 0)}.
+The latter case is handled via \code{model.matrix(~ as.factor(y) + 0)}.
 For "classification_error", both predictions and responses can be non-numeric.}
 
 \item{perms}{Number of permutations (default 4).}
@@ -169,14 +169,15 @@ situations. If there are K classes and n observations, the predictions form
 a (n x K) matrix of probabilities (with row-sums 1).
 The observed values \code{y} are either passed as (n x K) dummy matrix,
 or as discrete vector with corresponding levels.
-The latter case is turned into a dummy matrix via \code{model.matrix(~ y + 0)}.
-\item "classification_error": Misclassification error. This is currently the
-only prespecified loss that accepts non-numeric predictions. Both the
+The latter case is turned into a dummy matrix via
+\code{model.matrix(~ as.factor(y) + 0)}.
+\item "classification_error": Misclassification error. Both the
 observed values \code{y} and the predictions can be character/factor. This
 loss function can be used in non-probabilistic classification settings.
-BUT: Probabilistic classification (with "mlogloss") is preferred.
+BUT: Probabilistic classification (with "mlogloss") is clearly preferred in most
+situations.
 \item A function with signature \code{f(actual, predicted)}, returning a numeric
-vector of length n or a matrix with n rows, where n is the number of rows of \code{X}.
+vector or matrix of the same length as the input.
 }
 }
 

--- a/tests/testthat/test_average_loss.R
+++ b/tests/testthat/test_average_loss.R
@@ -44,28 +44,6 @@ test_that("average_loss() works with weights and grouped for regression", {
   expect_false(identical(s2, s3))
 })
 
-test_that("average_loss() can work with non-numeric predictions", {
-  pf <- function(m, X) rep("setosa", times = nrow(X))
-  expect_warning(average_loss(1, X = iris, y = iris$Species, pred_fun = pf))
-  expect_equal(
-    c(average_loss(
-      1, X = iris, y = iris$Species, pred_fun = pf, loss = "classification_error"
-    )),
-    2/3
-  )
-  expect_equal(
-    c(average_loss(
-      1, 
-      X = iris, 
-      y = iris$Species, 
-      pred_fun = pf, 
-      loss = "classification_error",
-      BY = iris$Species
-    )),
-    c(0, 1, 1)
-  )
-})
-
 #================================================
 # Multivariate regression
 #================================================
@@ -115,17 +93,38 @@ test_that("average_loss() works with weights and grouped (multi regression)", {
   expect_false(identical(s2, s3))
 })
 
+test_that("Single output multiple models works without recycling y", {
+  y <- iris$Sepal.Length
+  Y <- cbind(f1 = y, f2 = y)
+  fit1 <- lm(y ~ Petal.Length + Species, data = iris)
+  fit2 <- lm(y ~ Petal.Width + Sepal.Width, data = iris)
+  fit <- list(f1 = fit1, f2 = fit2)
+  pf <- function(m, x) sapply(fit, FUN = predict, newdata = x)
+  
+  s <- average_loss(fit, X = iris, y = y, pred_fun = pf)
+  expect_equal(drop(s), colMeans((y - pf(fit, iris))^2))
+  
+  s <- average_loss(fit, X = iris, y = y, loss = "absolute_error", pred_fun = pf)
+  expect_equal(drop(s), colMeans(abs(y - pf(fit, iris))))
+  
+  s <- average_loss(fit, X = iris, y = y, loss = "poisson", pred_fun = pf)
+  expect_equal(drop(s), colMeans(poisson()$dev.resid(Y, pf(fit, iris), 1)))
+  
+  s <- average_loss(fit, X = iris, y = y, loss = "gamma", pred_fun = pf)
+  expect_equal(drop(s), colMeans(Gamma()$dev.resid(Y, pf(fit, iris), 1)))
+})
+
 #================================================
-# Classification (probabilistic)
+# Classification
 #================================================
 
 y <- cbind(iris[, 1L] > 5.8, iris[, 2L] > 3) * 1
 fit <- lm(y ~ Petal.Length + Species, data = iris)
 pf <- function(m, X) {
   out <- predict(m, X)
-  out[out<0] <- 0
-  out[out>1] <- 1
-  setNames(out, c("V1", "V2"))
+  out[out < 0] <- 0
+  out[out > 1] <- 1
+  out
 }
 
 test_that("average_loss() works ungrouped (multivariate binary)", {
@@ -138,7 +137,9 @@ test_that("average_loss() works with groups (multivariate binary)", {
                     BY = iris$Species, pred_fun = pf)
   xpect <- by(binomial()$dev.resid(y, pf(fit, iris), 1) / 2, 
     FUN = colMeans, INDICES = iris$Species)
-  expect_equal(s, do.call(rbind, xpect))
+  xpect <- do.call(rbind, xpect)
+  colnames(s) <- colnames(xpect)
+  expect_equal(s, xpect)
 })
 
 test_that("average_loss() works with weights (multivariate binary)", {
@@ -167,12 +168,49 @@ test_that("average_loss() works with weights and grouped (multi)", {
 })
 
 test_that("mlogloss works with either matrix y or vector y", {
-  pred_fun <- function(m, X) cbind(1 - (0.1 + 0.7 * (X == 1)), 0.1 + 0.7 * (X == 1))
+  pf <- function(m, X) cbind(1 - (0.1 + 0.7 * (X == 1)), 0.1 + 0.7 * (X == 1))
   X <- cbind(z = c(1, 0, 0, 1, 1))
   y <- c("B", "A", "B", "B", "B")
   Y <- model.matrix(~ y + 0)
-  s1 <- average_loss(NULL, X = X, y = Y, loss = "mlogloss", pred_fun = pred_fun)
-  s2 <- average_loss(NULL, X = X, y = y, loss = "mlogloss", pred_fun = pred_fun)
+  s1 <- average_loss(NULL, X = X, y = Y, loss = "mlogloss", pred_fun = pf)
+  s2 <- average_loss(NULL, X = X, y = y, loss = "mlogloss", pred_fun = pf)
   expect_equal(s1, s2)
 })
 
+test_that("loss_mlogloss() is in line with loss_logloss() in binary case", {
+  y <- iris$Species == "setosa"
+  Y <- cbind(no = 1 - y, yes = y)
+  fit <- glm(y ~ Sepal.Length, data = iris, family = binomial())
+  pf <- function(m, X, multi = FALSE) {
+    out <- predict(m, X, type = "response")
+    if (multi) cbind(no = 1 - out, yes = out) else out
+  }
+  expect_equal(
+    average_loss(fit, X = iris, y = y, pred_fun = pf, loss = "logloss", BY = y),
+    average_loss(
+      fit, X = iris, y = y, pred_fun = pf, loss = "mlogloss", BY = y, multi = TRUE
+    )
+  )
+})
+
+test_that("classification_error works on factors", {
+  pf <- function(m, X) rep("setosa", times = nrow(X))
+  expect_warning(average_loss(1, X = iris, y = iris$Species, pred_fun = pf))
+  expect_equal(
+    c(average_loss(
+      1, X = iris, y = iris$Species, pred_fun = pf, loss = "classification_error"
+    )),
+    2/3
+  )
+  expect_equal(
+    c(average_loss(
+      1, 
+      X = iris, 
+      y = iris$Species, 
+      pred_fun = pf, 
+      loss = "classification_error",
+      BY = iris$Species
+    )),
+    c(0, 1, 1)
+  )
+})

--- a/tests/testthat/test_average_loss.R
+++ b/tests/testthat/test_average_loss.R
@@ -2,37 +2,43 @@
 fit <- lm(Sepal.Length ~ Sepal.Width + Species, data = iris)
 y <- iris$Sepal.Length
 
-test_that("average_loss() works ungrouped", {
-  s <- average_loss(fit, v = v, X = iris, y = y)
+test_that("average_loss() works ungrouped for regression", {
+  s <- average_loss(fit, X = iris, y = y)
   expect_equal(drop(s), mean((y - predict(fit, iris))^2))
   
-  s <- average_loss(fit, v = v, X = iris, y = y, loss = "absolute_error")
+  s <- average_loss(fit, X = iris, y = y, loss = "absolute_error")
   expect_equal(drop(s), mean(abs(y - predict(fit, iris))))
   
-  s <- average_loss(fit, v = v, X = iris, y = y, loss = loss_absolute_error)
+  s <- average_loss(fit, X = iris, y = y, loss = "poisson")
+  expect_equal(drop(s), mean(poisson()$dev.resid(y, predict(fit, iris), 1)))
+  
+  s <- average_loss(fit, X = iris, y = y, loss = "gamma")
+  expect_equal(drop(s), mean(Gamma()$dev.resid(y, predict(fit, iris), 1)))
+  
+  s <- average_loss(fit, X = iris, y = y, loss = loss_absolute_error)
   expect_equal(drop(s), mean(abs(y - predict(fit, iris))))
 })
 
-test_that("average_loss() works with groups", {
-  s <- average_loss(fit, v = v, X = iris, y = y, BY = iris$Species)
+test_that("average_loss() works with groups for regression", {
+  s <- average_loss(fit, X = iris, y = y, BY = iris$Species)
   xpect <- by((y - predict(fit, iris))^2, FUN = mean, INDICES = iris$Species)
   expect_equal(drop(s), c(xpect))
 })
 
-test_that("average_loss() works with weights", {
-  s1 <- average_loss(fit, v = v, X = iris, y = y)
-  s2 <- average_loss(fit, v = v, X = iris, y = y, w = rep(2, times = 150))
-  s3 <- average_loss(fit, v = v, X = iris, y = y, w = 1:150)
+test_that("average_loss() works with weights for regression", {
+  s1 <- average_loss(fit, X = iris, y = y)
+  s2 <- average_loss(fit, X = iris, y = y, w = rep(2, times = 150))
+  s3 <- average_loss(fit, X = iris, y = y, w = 1:150)
   
   expect_equal(s1, s2)
   expect_false(identical(s2, s3))
 })
 
-test_that("average_loss() works with weights and grouped", {
+test_that("average_loss() works with weights and grouped for regression", {
   g <- iris$Species
-  s1 <- average_loss(fit, v = v, X = iris, y = y, BY = g)
-  s2 <- average_loss(fit, v = v, X = iris, y = y, w = rep(2, times = 150), BY = g)
-  s3 <- average_loss(fit, v = v, X = iris, y = y, w = 1:150, BY = g)
+  s1 <- average_loss(fit, X = iris, y = y, BY = g)
+  s2 <- average_loss(fit, X = iris, y = y, w = rep(2, times = 150), BY = g)
+  s3 <- average_loss(fit, X = iris, y = y, w = 1:150, BY = g)
   
   expect_equal(s1, s2)
   expect_false(identical(s2, s3))
@@ -61,33 +67,87 @@ test_that("average_loss() can work with non-numeric predictions", {
 })
 
 #================================================
-# Multivariate model
+# Multivariate regression
 #================================================
 
 y <- as.matrix(iris[1:2])
 fit <- lm(y ~ Petal.Length + Species, data = iris)
 
-test_that("average_loss() works ungrouped (multi)", {
-  s <- average_loss(fit, v = v, X = iris, y = y)
+test_that("average_loss() works ungrouped (multi regression)", {
+  s <- average_loss(fit, X = iris, y = y)
   expect_equal(drop(s), colMeans((y - predict(fit, iris))^2))
   
-  s <- average_loss(fit, v = v, X = iris, y = y, loss = "absolute_error")
+  s <- average_loss(fit, X = iris, y = y, loss = "absolute_error")
   expect_equal(drop(s), colMeans(abs(y - predict(fit, iris))))
   
-  s <- average_loss(fit, v = v, X = iris, y = y, loss = loss_absolute_error)
+  s <- average_loss(fit, X = iris, y = y, loss = loss_absolute_error)
   expect_equal(drop(s), colMeans(abs(y - predict(fit, iris))))
+  
+  s <- average_loss(fit, X = iris, y = y, loss = "poisson")
+  expect_equal(drop(s), colMeans(poisson()$dev.resid(y, predict(fit, iris), 1)))
+  
+  s <- average_loss(fit, X = iris, y = y, loss = "gamma")
+  expect_equal(drop(s), colMeans(Gamma()$dev.resid(y, predict(fit, iris), 1)))
 })
 
-test_that("average_loss() works with groups (multi)", {
-  s <- average_loss(fit, v = v, X = iris, y = y, BY = iris$Species)
+test_that("average_loss() works with groups (multi regression)", {
+  s <- average_loss(fit, X = iris, y = y, BY = iris$Species)
   xpect <- by((y - predict(fit, iris))^2, FUN = colMeans, INDICES = iris$Species)
   expect_equal(s, do.call(rbind, xpect))
 })
 
-test_that("average_loss() works with weights (multi)", {
-  s1 <- average_loss(fit, v = v, X = iris, y = y)
-  s2 <- average_loss(fit, v = v, X = iris, y = y, w = rep(2, times = 150))
-  s3 <- average_loss(fit, v = v, X = iris, y = y, w = 1:150)
+test_that("average_loss() works with weights (multi regression)", {
+  s1 <- average_loss(fit, X = iris, y = y)
+  s2 <- average_loss(fit, X = iris, y = y, w = rep(2, times = 150))
+  s3 <- average_loss(fit, X = iris, y = y, w = 1:150)
+  
+  expect_equal(s1, s2)
+  expect_false(identical(s2, s3))
+})
+
+test_that("average_loss() works with weights and grouped (multi regression)", {
+  g <- iris$Species
+  s1 <- average_loss(fit, X = iris, y = y, BY = g)
+  s2 <- average_loss(fit, X = iris, y = y, w = rep(2, times = 150), BY = g)
+  s3 <- average_loss(fit, X = iris, y = y, w = 1:150, BY = g)
+  
+  expect_equal(s1, s2)
+  expect_false(identical(s2, s3))
+})
+
+#================================================
+# Classification (probabilistic)
+#================================================
+
+y <- cbind(iris[, 1L] > 5.8, iris[, 2L] > 3) * 1
+fit <- lm(y ~ Petal.Length + Species, data = iris)
+pf <- function(m, X) {
+  out <- predict(m, X)
+  out[out<0] <- 0
+  out[out>1] <- 1
+  setNames(out, c("V1", "V2"))
+}
+
+test_that("average_loss() works ungrouped (multivariate binary)", {
+  s <- average_loss(fit, X = iris, y = y, loss = "logloss", pred_fun = pf)
+  expect_equal(drop(s), colMeans(binomial()$dev.resid(y, pf(fit, iris), 1)) / 2)
+})
+
+test_that("average_loss() works with groups (multivariate binary)", {
+  s <- average_loss(fit, X = iris, y = y, loss = "logloss", 
+                    BY = iris$Species, pred_fun = pf)
+  xpect <- by(binomial()$dev.resid(y, pf(fit, iris), 1) / 2, 
+    FUN = colMeans, INDICES = iris$Species)
+  expect_equal(s, do.call(rbind, xpect))
+})
+
+test_that("average_loss() works with weights (multivariate binary)", {
+  s1 <- average_loss(fit, X = iris, y = y, 
+                     pred_fun = pf, loss = "logloss")
+  s2 <- average_loss(fit, X = iris, y = y, w = rep(2, times = 150), 
+                     pred_fun = pf, loss = "logloss")
+  s3 <- average_loss(fit, X = iris, y = y, w = 1:150, 
+                     pred_fun = pf, loss = "logloss")
   
   expect_equal(s1, s2)
   expect_false(identical(s2, s3))
@@ -95,9 +155,12 @@ test_that("average_loss() works with weights (multi)", {
 
 test_that("average_loss() works with weights and grouped (multi)", {
   g <- iris$Species
-  s1 <- average_loss(fit, v = v, X = iris, y = y, BY = g)
-  s2 <- average_loss(fit, v = v, X = iris, y = y, w = rep(2, times = 150), BY = g)
-  s3 <- average_loss(fit, v = v, X = iris, y = y, w = 1:150, BY = g)
+  s1 <- average_loss(fit, X = iris, y = y, BY = g, 
+                     pred_fun = pf, loss = "logloss")
+  s2 <- average_loss(fit, X = iris, y = y, w = rep(2, times = 150), BY = g,
+                     pred_fun = pf, loss = "logloss")
+  s3 <- average_loss(fit, X = iris, y = y, w = 1:150, BY = g,
+                     pred_fun = pf, loss = "logloss")
   
   expect_equal(s1, s2)
   expect_false(identical(s2, s3))
@@ -112,3 +175,4 @@ test_that("mlogloss works with either matrix y or vector y", {
   s2 <- average_loss(NULL, X = X, y = y, loss = "mlogloss", pred_fun = pred_fun)
   expect_equal(s1, s2)
 })
+

--- a/tests/testthat/test_losses.R
+++ b/tests/testthat/test_losses.R
@@ -4,8 +4,20 @@ test_that("losses are identical to stats package for specific case", {
   expect_equal(loss_squared_error(y, p), gaussian()$dev.resid(y, p, 1))
   expect_equal(loss_gamma(y, p), Gamma()$dev.resid(y, p, 1))
   
-  y <- 0:1
-  p <- c(0.1, 0.9)
+  y <- c(0, 0, 0, 1, 1, 1)
+  p <- c(0, 1, 0.1, 1, 0, 0.9)
+  expect_equal(loss_poisson(y, p), poisson()$dev.resid(y, p, 1))
+  expect_equal(loss_logloss(y, p), binomial()$dev.resid(y, p, 1) / 2)
+})
+
+test_that("losses are identical to stats package for specific case (multivariate)", {
+  y <- replicate(2, 1:10)
+  p <- y^2
+  expect_equal(loss_squared_error(y, p), gaussian()$dev.resid(y, p, 1))
+  expect_equal(loss_gamma(y, p), Gamma()$dev.resid(y, p, 1))
+  
+  y <- replicate(2, c(0, 0, 0, 1, 1, 1))
+  p <- replicate(2, c(0, 1, 0.1, 1, 0, 0.9))
   expect_equal(loss_poisson(y, p), poisson()$dev.resid(y, p, 1))
   expect_equal(loss_logloss(y, p), binomial()$dev.resid(y, p, 1) / 2)
 })
@@ -16,24 +28,22 @@ test_that("loss_absolute_error() works for specific case", {
   expect_equal(loss_absolute_error(y, p), abs(y - p))
 })
 
+test_that("loss_absolute_error() works for specific case (multivariate)", {
+  y <- replicate(2, 1:10)
+  p <- y^2
+  expect_equal(loss_absolute_error(y, p), abs(y - p))
+})
+
 test_that("loss_classification_error() works for specific case", {
   y <- iris$Species
   p <- rev(iris$Species)
   expect_equal(loss_classification_error(y, p), 0 + (y != p))
 })
 
-test_that("loss_mlogloss() is consistent with loss_logloss()", {
-  y <- 0:1
-  p <- c(0.1, 0.8)
-  expect_equal(loss_logloss(y, p), loss_mlogloss(cbind(y, 1 - y), cbind(p, 1 - p)))
-})
-
-test_that("The 0/0 case is okay with Poisson and logloss", {
-  y <- 0:1
-  p <- 0:1
-  expect_equal(loss_poisson(y, p), c(0, 0))
-  expect_equal(loss_logloss(y, p), c(0, 0))
-  expect_equal(loss_mlogloss(cbind(y, 1 - y), cbind(p, 1 - p)), c(0, 0))
+test_that("loss_classification_error() works for specific case (multivariate case)", {
+  y <- replicate(2, iris$Species)
+  p <- y[nrow(y):1, ]
+  expect_equal(loss_classification_error(y, p), 0 + (y != p))
 })
 
 test_that("Some errors are thrown", {
@@ -49,13 +59,14 @@ test_that("Some errors are thrown", {
   expect_error(check_dim(cbind(1:3), cbind(1:3, 1:3)))
 })
 
-test_that("xlogy is ok", {
+test_that("xlogy works (univariate and multivariate)", {
   expect_equal(xlogy(1:3, 1:3), (1:3) * log(1:3))
   expect_equal(xlogy(0:2, 0:2), c(0, 0, 2 * log(2)))
-  expect_equal(
-    xlogy(cbind(1:3, 0:2), cbind(1:3, 0:2)), 
-    cbind(xlogy(1:3, 1:3), xlogy(0:2, 0:2))
-  )
+  
+  x <- cbind(c(0,   0, 4), c( 0, 1, 2))
+  y <- cbind(c(100, 0, 0), c(10, 1, 2))
+  expected <- cbind(c(0, 0, -Inf), c(0, 0, 2 * log(2)))
+  expect_equal(xlogy(x, y), expected)
 })
 
 test_that("get_loss_fun() works", {


### PR DESCRIPTION
This PR introduced the possibility to pass a univariate response to `perm_importance()` and `average_loss()` when the predictions are multivariate (e.g., represent predictions of multiple models).