### PR TITLE
Pad zeros

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,9 @@
 
 ## Visible changes
 
-- `ice()` and `partial_dep()`: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid.
-- `h2()` will now always show the normalized $H^2$. Its options `normalize` and `squared` have been removed.
-- `h2_pairwise()` and `h2_threeway()` will now also include (some) combinations with value 0. Use `zero = FALSE` to drop them, see below.
-- `hstats()`: The default number of features considered for *three-way interactions* has been changed from `threeway_m = pairwise_m` to the more cautious `threeway_m = min(pairwise_m, 5L)`.
+- Grid of `ice()` and `partial_dep()`: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid.
+- `h2_pairwise()` and `h2_threeway()` will now also include 0 values. Use `zero = FALSE` to drop them, see below. The padding with 0 is done at no computational cost, and will affect only up to `pairwise_m` and `threeway_m` features.
+- `hstats()`: The default number of features considered for *three-way interactions* has been changed from `threeway_m = pairwise_m` to the more cautious `threeway_m = min(pairwise_m, 5L)`. Furthermore, `threeway_m` is capped at `pairwise_m`.
 - The `print()` method of `summary.hstats()` is less verbose.
 
 ## Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - `ice()` and `partial_dep()`: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid.
 - `h2()` will now always show the normalized $H^2$. Its options `normalize` and `squared` have been removed.
 - `h2_pairwise()` and `h2_threeway()` will now also include (some) combinations with value 0. Use `zero = FALSE` to drop them, see below.
+- `hstats()`: The default number of features considered for *three-way interactions* has been changed from `threeway_m = pairwise_m` to the more cautious `threeway_m = min(pairwise_m, 5L)`.
+- The `print()` method of `summary.hstats()` is less verbose.
 
 ## Improvements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,8 @@
 # hstats 0.3.0
 
-## Major user visible changes
+## Major visible changes
 
-- Grid calculation: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid. This affects `ice()`, `partial_dep()` and the exported helper functions `univariate_grid()` and `multivariate_grid()`.
-
-## Internal major changes
-
-- All available H-statistics are now calculated within `hstats()` and attached to the resulting object. Each statistic is stored as list with numerator and denominator matrices/vectors. The functions `h2()`, `h2_overall()`, `h2_pairwise()`, and `h2_threeway()`, `print.hstats()`, `summary().hstats()`, `plot.hstats()` will use these without having to recalculate the required numerators and denominators. The results, however, are unchanged.
+- `ice()` and `partial_dep()`: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid. 
 
 ## Minor improvements
 
@@ -16,6 +12,10 @@
 
 - All progress bars were initialized 1 step too late.
 - `perm_importance()` and `average_loss()` would fail for "mlogloss" in case the response `y` was univariate *and* non-factor/non-character.
+
+## Other changes
+
+- All available H-statistics are now calculated within `hstats()` and attached to the resulting object. Each statistic is stored as list with numerator and denominator matrices/vectors. The functions `h2()`, `h2_overall()`, `h2_pairwise()`, and `h2_threeway()`, `print.hstats()`, `summary().hstats()`, `plot.hstats()` will use these without having to recalculate the required numerators and denominators. The results, however, are unchanged.
 
 # hstats 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,12 +3,12 @@
 ## Visible changes
 
 - `ice()` and `partial_dep()`: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid.
-- `h2()` will now always show the normalized $H^2$. The options `normalize` and `squared` have been removed.
-- `h2_overall()` will only show features with positive interaction.
+- `h2()` will now always show the normalized $H^2$. Its options `normalize` and `squared` have been removed.
+- `h2_pairwise()` and `h2_threeway()` will now also include (some) combinations with value 0. Use `zero = FALSE` to drop them, see below.
 
 ## Improvements
 
-- `h2_overall()`, `h2_pairwise()`, `h2_threeway()`, `plot.hstats()`, and `summary.hstats()` have received an argument `drop_zero = TRUE`. Set to `FALSE` to also show statistics having value 0.
+- `h2_overall()`, `h2_pairwise()`, `h2_threeway()`, `plot.hstats()`, and `summary.hstats()` have received an argument `zero = TRUE`. Set to `FALSE` to drop statistics having value 0.
 - `perm_importance()` and `average_loss()` will now recycle a univariate response when combined with multivariate predictions. This is useful, e.g., when the prediction function represents the predictions of multiple models that should be evaluated against a common response.
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,14 @@
 # hstats 0.3.0
 
-## Major visible changes
+## Visible changes
 
-- `ice()` and `partial_dep()`: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid. 
+- `ice()` and `partial_dep()`: So far, the default grid strategy "uniform" used `pretty()` to generate the evaluation points. To provide more predictable grid sizes, and to be more in line with other implementations of partial dependence and ICE, we now use `seq()` to create the uniform grid.
+- `h2()` will now always show the normalized $H^2$. The options `normalize` and `squared` have been removed.
+- `h2_overall()` will only show features with positive interaction.
 
-## Minor improvements
+## Improvements
 
+- `h2_overall()`, `h2_pairwise()`, `h2_threeway()`, `plot.hstats()`, and `summary.hstats()` have received an argument `drop_zero = TRUE`. Set to `FALSE` to also show statistics having value 0.
 - `perm_importance()` and `average_loss()` will now recycle a univariate response when combined with multivariate predictions. This is useful, e.g., when the prediction function represents the predictions of multiple models that should be evaluated against a common response.
 
 ## Bug fixes

--- a/R/H2.R
+++ b/R/H2.R
@@ -65,13 +65,12 @@ h2.default <- function(object, ...) {
 
 #' @describeIn h2 Total interaction strength from "interact" object.
 #' @export
-h2.hstats <- function(object, normalize = TRUE, squared = TRUE, eps = 1e-8, ...) {
+h2.hstats <- function(object, eps = 1e-8, ...) {
   postprocess(
     num = object$h2$num,
     denom = object$h2$denom,
-    normalize = normalize, 
-    squared = squared, 
-    sort = FALSE, 
+    sort = FALSE,
+    drop_zero = FALSE,
     eps = eps
   )
 }

--- a/R/H2.R
+++ b/R/H2.R
@@ -65,10 +65,12 @@ h2.default <- function(object, ...) {
 
 #' @describeIn h2 Total interaction strength from "interact" object.
 #' @export
-h2.hstats <- function(object, eps = 1e-8, ...) {
+h2.hstats <- function(object, normalize = TRUE, squared = TRUE, eps = 1e-8, ...) {
   postprocess(
     num = object$h2$num,
     denom = object$h2$denom,
+    normalize = normalize, 
+    squared = squared,
     sort = FALSE,
     eps = eps
   )

--- a/R/H2.R
+++ b/R/H2.R
@@ -70,7 +70,6 @@ h2.hstats <- function(object, eps = 1e-8, ...) {
     num = object$h2$num,
     denom = object$h2$denom,
     sort = FALSE,
-    drop_zero = FALSE,
     eps = eps
   )
 }

--- a/R/H2_overall.R
+++ b/R/H2_overall.R
@@ -44,7 +44,7 @@
 #' @param sort Should results be sorted? Default is `TRUE`.
 #'   (Multioutput is sorted by row means.)
 #' @param top_m How many rows should be shown? (`Inf` to show all.)
-#' @param drop_zero Should rows with all 0 be dropped? Default is `TRUE`.
+#' @param zero Should rows with all 0 be shown? Default is `TRUE`.
 #' @param eps Threshold below which numerator values are set to 0.
 #' @param plot Should results be plotted as barplot? Default is `FALSE`.
 #' @param fill Color of bar (only for univariate statistics).
@@ -65,7 +65,7 @@
 #' # MODEL 2: Multi-response linear regression
 #' fit <- lm(as.matrix(iris[1:2]) ~ Petal.Length + Petal.Width * Species, data = iris)
 #' s <- hstats(fit, X = iris[3:5], verbose = FALSE)
-#' h2_overall(s, plot = TRUE)
+#' h2_overall(s, plot = TRUE, zero = FALSE)
 h2_overall <- function(object, ...) {
   UseMethod("h2_overall")
 }
@@ -79,7 +79,7 @@ h2_overall.default <- function(object, ...) {
 #' @describeIn h2_overall Overall interaction strength from "hstats" object.
 #' @export
 h2_overall.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
-                              top_m = 15L, drop_zero = TRUE, eps = 1e-8, 
+                              top_m = 15L, zero = TRUE, eps = 1e-8, 
                               plot = FALSE, fill = "#2b51a1", ...) {
   s <- object$h2_overall
   out <- postprocess(
@@ -89,7 +89,7 @@ h2_overall.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = T
     squared = squared, 
     sort = sort, 
     top_m = top_m,
-    drop_zero = drop_zero,
+    zero = zero,
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out

--- a/R/H2_overall.R
+++ b/R/H2_overall.R
@@ -108,11 +108,9 @@ h2_overall.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = T
 #'   "f", "F_not_j", "F_j", "mean_f2", and "w".
 #' @returns A list with the numerator and denominator statistics.
 h2_overall_raw <- function(x) {
-  num <- with(x, matrix(nrow = length(v), ncol = K, dimnames = list(v, pred_names)))
-  
+  num <- init_numerator(x, way = 1L)
   for (z in x[["v"]]) {
     num[z, ] <- with(x, wcolMeans((f - F_j[[z]] - F_not_j[[z]])^2, w = w))
   }
-  
   list(num = num, denom = x[["mean_f2"]])
 }

--- a/R/H2_overall.R
+++ b/R/H2_overall.R
@@ -44,6 +44,7 @@
 #' @param sort Should results be sorted? Default is `TRUE`.
 #'   (Multioutput is sorted by row means.)
 #' @param top_m How many rows should be shown? (`Inf` to show all.)
+#' @param drop_zero Should rows with all 0 be dropped? Default is `TRUE`.
 #' @param eps Threshold below which numerator values are set to 0.
 #' @param plot Should results be plotted as barplot? Default is `FALSE`.
 #' @param fill Color of bar (only for univariate statistics).
@@ -78,8 +79,8 @@ h2_overall.default <- function(object, ...) {
 #' @describeIn h2_overall Overall interaction strength from "hstats" object.
 #' @export
 h2_overall.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
-                              top_m = 15L, eps = 1e-8, plot = FALSE, fill = "#2b51a1", 
-                              ...) {
+                              top_m = 15L, drop_zero = TRUE, eps = 1e-8, 
+                              plot = FALSE, fill = "#2b51a1", ...) {
   s <- object$h2_overall
   out <- postprocess(
     num = s$num,
@@ -87,7 +88,8 @@ h2_overall.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = T
     normalize = normalize, 
     squared = squared, 
     sort = sort, 
-    top_m = top_m, 
+    top_m = top_m,
+    drop_zero = drop_zero,
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out

--- a/R/H2_pairwise.R
+++ b/R/H2_pairwise.R
@@ -116,11 +116,7 @@ h2_pairwise.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = 
 #'   "F_jk", "F_j", and "w".
 #' @returns A list with the numerator and denominator statistics.
 h2_pairwise_raw <- function(x) {
-  # Initialize matrices
-  cn0 <- combn(x[["v_pairwise_0"]], 2L, FUN = paste, collapse = ":")
-  num <- with(
-    x, matrix(0, nrow = length(cn0), ncol = K, dimnames = list(cn0, pred_names))
-  )
+  num <- init_numerator(x, way = 2L)
   denom <- num + 1
     
   # Note that F_jk are in the same order as x[["combs2"]]

--- a/R/H2_pairwise.R
+++ b/R/H2_pairwise.R
@@ -107,21 +107,25 @@ h2_pairwise.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = 
 #' 
 #' @noRd
 #' @keywords internal
-#' @param x A list containing the elements "combs2", "K", "pred_names", 
+#' @param x A list containing the elements "combs2", "v_pairwise_0", "K", "pred_names", 
 #'   "F_jk", "F_j", and "w".
 #' @returns A list with the numerator and denominator statistics.
 h2_pairwise_raw <- function(x) {
-  combs <- x[["combs2"]]
-  
-  # Note that F_jk are in the same order as combs
-  num <- denom <- with(
-    x, matrix(nrow = length(combs), ncol = K, dimnames = list(names(combs), pred_names))
+  # Initialize matrices
+  cn0 <- combn(x[["v_pairwise_0"]], 2L, FUN = paste, collapse = ":")
+  num <- with(
+    x, matrix(0, nrow = length(cn0), ncol = K, dimnames = list(cn0, pred_names))
   )
-  
-  for (i in seq_along(combs)) {
-    z <- combs[[i]]
-    num[i, ] <- with(x, wcolMeans((F_jk[[i]] - F_j[[z[1L]]] - F_j[[z[2L]]])^2, w = w))
-    denom[i, ] <- with(x, wcolMeans(F_jk[[i]]^2, w = w))
+  denom <- num + 1
+    
+  # Note that F_jk are in the same order as x[["combs2"]]
+  combs <- x[["combs2"]]
+  if (!is.null(combs)) {
+    for (nm in names(combs)) {
+      z <- combs[[nm]]
+      num[nm, ] <- with(x, wcolMeans((F_jk[[nm]] - F_j[[z[1L]]] - F_j[[z[2L]]])^2, w = w))
+      denom[nm, ] <- with(x, wcolMeans(F_jk[[nm]]^2, w = w))
+    }    
   }
   
   list(num = num, denom = denom)

--- a/R/H2_pairwise.R
+++ b/R/H2_pairwise.R
@@ -62,6 +62,9 @@
 #' # (for features with strongest overall interactions)
 #' h2_pairwise(s)
 #' 
+#' # Do not drop zeros
+#' h2_pairwise(s, drop_zero = FALSE)
+#' 
 #' # Absolute measure as alternative
 #' h2_pairwise(s, normalize = FALSE, squared = FALSE)
 #' 
@@ -69,6 +72,9 @@
 #' fit <- lm(as.matrix(iris[1:2]) ~ Petal.Length + Petal.Width * Species, data = iris)
 #' s <- hstats(fit, X = iris[3:5], verbose = FALSE)
 #' h2_pairwise(s, plot = TRUE)
+#' 
+#' # Do not drop zeros
+#' h2_pairwise(s, drop_zero = FALSE, plot = TRUE)
 h2_pairwise <- function(object, ...) {
   UseMethod("h2_pairwise")
 }
@@ -82,8 +88,8 @@ h2_pairwise.default <- function(object, ...) {
 #' @describeIn h2_pairwise Pairwise interaction strength from "hstats" object.
 #' @export
 h2_pairwise.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
-                               top_m = 15L, eps = 1e-8, plot = FALSE, 
-                               fill = "#2b51a1", ...) {
+                               top_m = 15L, drop_zero = TRUE, eps = 1e-8, 
+                               plot = FALSE, fill = "#2b51a1", ...) {
   s <- object$h2_pairwise
   if (is.null(s)) {
     return(NULL)
@@ -94,7 +100,8 @@ h2_pairwise.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = 
     normalize = normalize, 
     squared = squared, 
     sort = sort, 
-    top_m = top_m, 
+    top_m = top_m,
+    drop_zero = drop_zero,
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out

--- a/R/H2_pairwise.R
+++ b/R/H2_pairwise.R
@@ -61,9 +61,7 @@
 #' # Proportion of joint effect coming from pairwise interaction
 #' # (for features with strongest overall interactions)
 #' h2_pairwise(s)
-#' 
-#' # Drop 0
-#' h2_pairwise(s, zero = FALSE)
+#' h2_pairwise(s, zero = FALSE)  # Drop 0
 #' 
 #' # Absolute measure as alternative
 #' h2_pairwise(s, normalize = FALSE, squared = FALSE)

--- a/R/H2_pairwise.R
+++ b/R/H2_pairwise.R
@@ -62,8 +62,8 @@
 #' # (for features with strongest overall interactions)
 #' h2_pairwise(s)
 #' 
-#' # Do not drop zeros
-#' h2_pairwise(s, drop_zero = FALSE)
+#' # Drop 0
+#' h2_pairwise(s, zero = FALSE)
 #' 
 #' # Absolute measure as alternative
 #' h2_pairwise(s, normalize = FALSE, squared = FALSE)
@@ -72,9 +72,7 @@
 #' fit <- lm(as.matrix(iris[1:2]) ~ Petal.Length + Petal.Width * Species, data = iris)
 #' s <- hstats(fit, X = iris[3:5], verbose = FALSE)
 #' h2_pairwise(s, plot = TRUE)
-#' 
-#' # Do not drop zeros
-#' h2_pairwise(s, drop_zero = FALSE, plot = TRUE)
+#' h2_pairwise(s, zero = FALSE, plot = TRUE)
 h2_pairwise <- function(object, ...) {
   UseMethod("h2_pairwise")
 }
@@ -88,7 +86,7 @@ h2_pairwise.default <- function(object, ...) {
 #' @describeIn h2_pairwise Pairwise interaction strength from "hstats" object.
 #' @export
 h2_pairwise.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
-                               top_m = 15L, drop_zero = TRUE, eps = 1e-8, 
+                               top_m = 15L, zero = TRUE, eps = 1e-8, 
                                plot = FALSE, fill = "#2b51a1", ...) {
   s <- object$h2_pairwise
   if (is.null(s)) {
@@ -101,7 +99,7 @@ h2_pairwise.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = 
     squared = squared, 
     sort = sort, 
     top_m = top_m,
-    drop_zero = drop_zero,
+    zero = zero,
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out

--- a/R/H2_threeway.R
+++ b/R/H2_threeway.R
@@ -69,8 +69,8 @@ h2_threeway.default <- function(object, ...) {
 #' @describeIn h2_threeway Pairwise interaction strength from "hstats" object.
 #' @export
 h2_threeway.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
-                               top_m = 15L, eps = 1e-8, plot = FALSE, 
-                               fill = "#2b51a1", ...) {
+                               top_m = 15L, drop_zero = TRUE, eps = 1e-8, 
+                               plot = FALSE, fill = "#2b51a1", ...) {
   s <- object$h2_threeway
   if (is.null(s)) {
     return(NULL)
@@ -81,7 +81,8 @@ h2_threeway.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = 
     normalize = normalize, 
     squared = squared, 
     sort = sort, 
-    top_m = top_m, 
+    top_m = top_m,
+    drop_zero = drop_zero,
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out

--- a/R/H2_threeway.R
+++ b/R/H2_threeway.R
@@ -69,7 +69,7 @@ h2_threeway.default <- function(object, ...) {
 #' @describeIn h2_threeway Pairwise interaction strength from "hstats" object.
 #' @export
 h2_threeway.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
-                               top_m = 15L, drop_zero = TRUE, eps = 1e-8, 
+                               top_m = 15L, zero = TRUE, eps = 1e-8, 
                                plot = FALSE, fill = "#2b51a1", ...) {
   s <- object$h2_threeway
   if (is.null(s)) {
@@ -82,7 +82,7 @@ h2_threeway.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = 
     squared = squared, 
     sort = sort, 
     top_m = top_m,
-    drop_zero = drop_zero,
+    zero = zero,
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out

--- a/R/H2_threeway.R
+++ b/R/H2_threeway.R
@@ -99,11 +99,7 @@ h2_threeway.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = 
 #'   "F_jkl", "F_jk", "F_j", and "w".
 #' @returns A list with the numerator and denominator statistics.
 h2_threeway_raw <- function(x) {
-  # Initialize matrices
-  cn0 <- utils::combn(x[["v_threeway_0"]], 3L, FUN = paste, collapse = ":")
-  num <- with(
-    x, matrix(0, nrow = length(cn0), ncol = K, dimnames = list(cn0, pred_names))
-  )
+  num <- init_numerator(x, way = 3L)
   denom <- num + 1
   
   # Note that the F_jkl are in the same order as x[["combs3"]]

--- a/R/hstats.R
+++ b/R/hstats.R
@@ -90,7 +90,7 @@
 #' s <- hstats(fit, X = iris[-1])
 #' s
 #' plot(s)
-#' plot(s, zero = FALSE)  # Drop 0 interaction rows
+#' plot(s, zero = FALSE)  # Drop 0
 #' summary(s)
 #'   
 #' # Absolute pairwise interaction strengths

--- a/R/hstats.R
+++ b/R/hstats.R
@@ -406,14 +406,14 @@ plot.hstats <- function(x, which = 1:2, normalize = TRUE, squared = TRUE, sort =
     eps = eps
   )
   
-  nms <- c(Overall = "h2_overall", Pairwise = "h2_pairwise", Threeway = "h2_threeway")
-  su <- su[nms[which]]
-  
-  if (length(su) == 0L) {
+  # This part could be simplified, especially the "match()"
+  stat_names <- c("h2_overall", "h2_pairwise", "h2_threeway")[which]
+  stat_labs <- c("Overall", "Pairwise", "Three-way")[which]
+  ok <- stat_names[stat_names %in% names(su)]
+  if (length(ok) == 0L) {
     return(NULL)
   }
-  
-  dat <- lapply(names(su), FUN = function(nm) mat2df(su[[nm]], id = nm))
+  dat <- lapply(ok, FUN = function(nm) mat2df(su[[nm]], id = stat_labs[match(nm, stat_names)]))
   dat <- do.call(rbind, dat)
   
   p <- ggplot2::ggplot(dat, ggplot2::aes(x = value_, y = variable_)) +

--- a/R/hstats.R
+++ b/R/hstats.R
@@ -91,7 +91,7 @@
 #' s <- hstats(fit, X = iris[-1])
 #' s
 #' plot(s)
-#' plot(s, drop_zero = FALSE)
+#' plot(s, zero = FALSE)
 #' summary(s)
 #'   
 #' # Absolute pairwise interaction strengths
@@ -112,9 +112,7 @@
 #' 
 #' # On original scale, we have interactions everywhere...
 #' s <- hstats(fit, X = iris[-1], type = "response", verbose = FALSE)
-#' 
-#' # All three types use different denominators
-#' plot(s, which = 1:3, ncol = 1)
+#' plot(s, which = 1:3, ncol = 1)  # All three types use different denominators
 #' 
 #' # All statistics on same scale (of predictions)
 #' plot(s, which = 1:3, squared = FALSE, normalize = FALSE, facet_scale = "free_y")
@@ -327,14 +325,14 @@ print.hstats <- function(x, ...) {
 #' @export
 #' @seealso See [hstats()] for examples.
 summary.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
-                           top_m = Inf, drop_zero = TRUE, eps = 1e-8, ...) {
+                           top_m = Inf, zero = TRUE, eps = 1e-8, ...) {
   args <- list(
     object = object, 
     normalize = normalize, 
     squared = squared, 
     sort = sort,
     top_m = top_m,
-    drop_zero = drop_zero,
+    zero = zero,
     eps = eps,
     plot = FALSE
   )
@@ -370,7 +368,7 @@ print.summary_hstats <- function(x, ...) {
   for (nm in setdiff(names(Filter(Negate(is.null), x)), "normalize")) {
     cat(txt[[nm]])
     cat("\n")
-    print(utils::head(drop(x[[nm]])))
+    print(utils::head(x[[nm]]))
     cat("\n")
   }
   invisible(x)
@@ -393,7 +391,7 @@ print.summary_hstats <- function(x, ...) {
 #' @export
 #' @seealso See [hstats()] for examples.
 plot.hstats <- function(x, which = 1:2, normalize = TRUE, squared = TRUE, sort = TRUE, 
-                        top_m = 15L, drop_zero = TRUE, eps = 1e-8, fill = "#2b51a1", 
+                        top_m = 15L, zero = TRUE, eps = 1e-8, fill = "#2b51a1", 
                         facet_scales = "free", ncol = 2L, rotate_x = FALSE, ...) {
   su <- summary(
     x, 
@@ -401,7 +399,7 @@ plot.hstats <- function(x, which = 1:2, normalize = TRUE, squared = TRUE, sort =
     squared = squared, 
     sort = sort, 
     top_m = top_m,
-    drop_zero = drop_zero,
+    zero = zero,
     eps = eps
   )
   nms <- c("h2_overall", "h2_pairwise", "h2_threeway")

--- a/R/hstats.R
+++ b/R/hstats.R
@@ -321,7 +321,8 @@ print.hstats <- function(x, ...) {
 #' @inheritParams h2_overall
 #' @param ... Currently not used.
 #' @returns 
-#'   An object of class "summary_hstats" representing a named list with statistics.
+#'   An object of class "summary_hstats" representing a named list with statistics
+#'   and `normalize`.
 #' @export
 #' @seealso See [hstats()] for examples.
 summary.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE, 
@@ -339,7 +340,8 @@ summary.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE
     h2 = h2(object, normalize = normalize, squared = squared, eps = eps), 
     h2_overall = do.call(h2_overall, args), 
     h2_pairwise = do.call(h2_pairwise, args), 
-    h2_threeway = do.call(h2_threeway, args)
+    h2_threeway = do.call(h2_threeway, args),
+    normalize = normalize
   )
   class(out) <- "summary_hstats"
   out
@@ -355,14 +357,15 @@ summary.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE
 #' @export
 #' @seealso See [hstats()] for examples.
 print.summary_hstats <- function(x, ...) {
+  flag <- if (x[["normalize"]]) "relative" else "absolute"
   txt <- c(
-    h2 = "Proportion of prediction variability unexplained by main effects of v",
-    h2_overall = "Strongest overall interactions", 
-    h2_pairwise = "Strongest pairwise interactions",
-    h2_threeway = "Strongest three-way interactions"
+    h2 = sprintf("Prediction variability unexplained by main effects of v (%s)", flag),
+    h2_overall = sprintf("Strongest %s overall interactions", flag), 
+    h2_pairwise = sprintf("Strongest %s pairwise interactions", flag),
+    h2_threeway = sprintf("Strongest %s three-way interactions", flag)
   )
   
-  for (nm in names(Filter(Negate(is.null), x))) {
+  for (nm in setdiff(names(Filter(Negate(is.null), x)), "normalize")) {
     cat(txt[[nm]])
     cat("\n")
     print(utils::head(drop(x[[nm]])))

--- a/R/hstats.R
+++ b/R/hstats.R
@@ -338,7 +338,7 @@ summary.hstats <- function(object, normalize = TRUE, squared = TRUE, sort = TRUE
     plot = FALSE
   )
   out <- list(
-    h2 = h2(object, eps = eps), 
+    h2 = h2(object, normalize = normalize, squared = squared, eps = eps), 
     h2_overall = do.call(h2_overall, args), 
     h2_pairwise = do.call(h2_pairwise, args), 
     h2_threeway = do.call(h2_threeway, args),
@@ -361,7 +361,7 @@ print.summary_hstats <- function(x, ...) {
   flag <- if (x[["normalize"]]) "relative" else "absolute"
 
   txt <- c(
-    h2 = "Relative prediction variability unexplained by main effects",
+    h2 = "Prediction variability unexplained by main effects",
     h2_overall = sprintf("Strongest %s overall interactions", flag), 
     h2_pairwise = sprintf("Strongest %s pairwise interactions", flag),
     h2_threeway = sprintf("Strongest %s three-way interaction", flag)

--- a/R/pd_importance.R
+++ b/R/pd_importance.R
@@ -57,9 +57,8 @@ pd_importance.default <- function(object, ...) {
 #' @describeIn pd_importance PD based feature importance from "hstats" object.
 #' @export
 pd_importance.hstats <- function(object, normalize = TRUE, squared = TRUE, 
-                                 sort = TRUE, top_m = 15L, zero = TRUE, 
-                                 eps = 1e-8, plot = FALSE, 
-                                 fill = "#2b51a1", ...) {
+                                 sort = TRUE, top_m = 15L, zero = TRUE, eps = 1e-8, 
+                                 plot = FALSE, fill = "#2b51a1", ...) {
   num <- with(
     object, matrix(nrow = length(v), ncol = K, dimnames = list(v, pred_names))
   )

--- a/R/pd_importance.R
+++ b/R/pd_importance.R
@@ -57,7 +57,8 @@ pd_importance.default <- function(object, ...) {
 #' @describeIn pd_importance PD based feature importance from "hstats" object.
 #' @export
 pd_importance.hstats <- function(object, normalize = TRUE, squared = TRUE, 
-                                 sort = TRUE, top_m = 15L, eps = 1e-8, plot = FALSE, 
+                                 sort = TRUE, top_m = 15L, drop_zero = FALSE, 
+                                 eps = 1e-8, plot = FALSE, 
                                  fill = "#2b51a1", ...) {
   num <- with(
     object, matrix(nrow = length(v), ncol = K, dimnames = list(v, pred_names))
@@ -71,7 +72,8 @@ pd_importance.hstats <- function(object, normalize = TRUE, squared = TRUE,
     normalize = normalize, 
     squared = squared, 
     sort = sort, 
-    top_m = top_m, 
+    top_m = top_m,
+    drop_zero = drop_zero,
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out

--- a/R/pd_importance.R
+++ b/R/pd_importance.R
@@ -59,9 +59,7 @@ pd_importance.default <- function(object, ...) {
 pd_importance.hstats <- function(object, normalize = TRUE, squared = TRUE, 
                                  sort = TRUE, top_m = 15L, zero = TRUE, eps = 1e-8, 
                                  plot = FALSE, fill = "#2b51a1", ...) {
-  num <- with(
-    object, matrix(nrow = length(v), ncol = K, dimnames = list(v, pred_names))
-  )
+  num <- init_numerator(object, way = 1L)
   for (z in object[["v"]]) {
     num[z, ] <- with(object, wcolMeans((f - F_not_j[[z]])^2, w = w))
   }

--- a/R/pd_importance.R
+++ b/R/pd_importance.R
@@ -57,7 +57,7 @@ pd_importance.default <- function(object, ...) {
 #' @describeIn pd_importance PD based feature importance from "hstats" object.
 #' @export
 pd_importance.hstats <- function(object, normalize = TRUE, squared = TRUE, 
-                                 sort = TRUE, top_m = 15L, drop_zero = FALSE, 
+                                 sort = TRUE, top_m = 15L, zero = TRUE, 
                                  eps = 1e-8, plot = FALSE, 
                                  fill = "#2b51a1", ...) {
   num <- with(
@@ -73,7 +73,7 @@ pd_importance.hstats <- function(object, normalize = TRUE, squared = TRUE,
     squared = squared, 
     sort = sort, 
     top_m = top_m,
-    drop_zero = drop_zero,
+    zero = zero,
     eps = eps
   )
   if (plot) plot_stat(out, fill = fill, ...) else out

--- a/R/utils.R
+++ b/R/utils.R
@@ -363,8 +363,8 @@ init_numerator <- function(x, way = 1L) {
     v_cand_0 <- v_cand
   }
   
-  # Get all interactions of order "way"
-  cn0 <- combn(v_cand_0, m = way, FUN = paste, collapse = ":")
+  # Get all interactions of order "way". c() turns the array into a vector
+  cn0 <- c(utils::combn(v_cand_0, m = way, FUN = paste, collapse = ":"))
   matrix(0, nrow = length(cn0), ncol = K, dimnames = list(cn0, pred_names))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -323,6 +323,51 @@ mat2df <- function(mat, id = "Overall") {
   poor_man_stack(out, to_stack = pred_names)
 }
 
+#' Initializor of Numerator Statistics
+#' 
+#' Internal helper function that returns a matrix of all zeros with the right
+#' column and row names for statistics of any "way". If some features have been dropped
+#' from the statistics calculations, they are added as 0.
+#' 
+#' @noRd
+#' @keywords internal
+#' @param x A list containing the elements "v", "K", "pred_names", "v_pairwise", 
+#'   "v_threeway", "pairwise_m", "threeway_m".
+#' @param way Integer between 1 and 3 of the order of the interaction.
+#' @returns A matrix of all zeros.
+init_numerator <- function(x, way = 1L) {
+  stopifnot(way %in% 1:3)
+  
+  v <- x[["v"]]
+  K <- x[["K"]]
+  pred_names <- x[["pred_names"]]
+  
+  # Simple case
+  if (way == 1L) {
+    return(matrix(nrow = length(v), ncol = K, dimnames = list(v, pred_names)))
+  }
+  
+  # Determine v_cand_0, which is v_cand with additional features to end up with length m
+  if (way == 2L) {
+    v_cand <- x[["v_pairwise"]]
+    m <- x[["pairwise_m"]]
+  } else {
+    v_cand <- x[["v_threeway"]]
+    m <- x[["threeway_m"]]
+  }
+  m_miss <- m - length(v_cand)
+  if (m_miss > 0L) {
+    v_cand_0 <- c(v_cand, utils::head(setdiff(v, v_cand), m_miss))
+    v_cand_0 <- v[v %in% v_cand_0]  # Bring into order of v
+  } else {
+    v_cand_0 <- v_cand
+  }
+  
+  # Get all interactions of order "way"
+  cn0 <- combn(v_cand_0, m = way, FUN = paste, collapse = ":")
+  matrix(0, nrow = length(cn0), ncol = K, dimnames = list(cn0, pred_names))
+}
+
 #' Bin into Quantiles
 #' 
 #' Internal function. Applies [cut()] to quantile breaks.

--- a/man/H2.Rd
+++ b/man/H2.Rd
@@ -10,12 +10,16 @@ h2(object, ...)
 
 \method{h2}{default}(object, ...)
 
-\method{h2}{hstats}(object, eps = 1e-08, ...)
+\method{h2}{hstats}(object, normalize = TRUE, squared = TRUE, eps = 1e-08, ...)
 }
 \arguments{
 \item{object}{Object of class "hstats".}
 
 \item{...}{Currently unused.}
+
+\item{normalize}{Should statistics be normalized? Default is \code{TRUE}.}
+
+\item{squared}{Should \emph{squared} statistics be returned? Default is \code{TRUE}.}
 
 \item{eps}{Threshold below which numerator values are set to 0.}
 }

--- a/man/H2.Rd
+++ b/man/H2.Rd
@@ -10,16 +10,12 @@ h2(object, ...)
 
 \method{h2}{default}(object, ...)
 
-\method{h2}{hstats}(object, normalize = TRUE, squared = TRUE, eps = 1e-08, ...)
+\method{h2}{hstats}(object, eps = 1e-08, ...)
 }
 \arguments{
 \item{object}{Object of class "hstats".}
 
 \item{...}{Currently unused.}
-
-\item{normalize}{Should statistics be normalized? Default is \code{TRUE}.}
-
-\item{squared}{Should \emph{squared} statistics be returned? Default is \code{TRUE}.}
 
 \item{eps}{Threshold below which numerator values are set to 0.}
 }

--- a/man/H2_overall.Rd
+++ b/man/H2_overall.Rd
@@ -16,6 +16,7 @@ h2_overall(object, ...)
   squared = TRUE,
   sort = TRUE,
   top_m = 15L,
+  zero = TRUE,
   eps = 1e-08,
   plot = FALSE,
   fill = "#2b51a1",
@@ -35,6 +36,8 @@ h2_overall(object, ...)
 (Multioutput is sorted by row means.)}
 
 \item{top_m}{How many rows should be shown? (\code{Inf} to show all.)}
+
+\item{zero}{Should rows with all 0 be shown? Default is \code{TRUE}.}
 
 \item{eps}{Threshold below which numerator values are set to 0.}
 
@@ -103,7 +106,7 @@ h2_overall(s, plot = TRUE)
 # MODEL 2: Multi-response linear regression
 fit <- lm(as.matrix(iris[1:2]) ~ Petal.Length + Petal.Width * Species, data = iris)
 s <- hstats(fit, X = iris[3:5], verbose = FALSE)
-h2_overall(s, plot = TRUE)
+h2_overall(s, plot = TRUE, zero = FALSE)
 }
 \references{
 Friedman, Jerome H., and Bogdan E. Popescu. \emph{"Predictive Learning via Rule Ensembles."}

--- a/man/H2_pairwise.Rd
+++ b/man/H2_pairwise.Rd
@@ -16,6 +16,7 @@ h2_pairwise(object, ...)
   squared = TRUE,
   sort = TRUE,
   top_m = 15L,
+  zero = TRUE,
   eps = 1e-08,
   plot = FALSE,
   fill = "#2b51a1",
@@ -35,6 +36,8 @@ h2_pairwise(object, ...)
 (Multioutput is sorted by row means.)}
 
 \item{top_m}{How many rows should be shown? (\code{Inf} to show all.)}
+
+\item{zero}{Should rows with all 0 be shown? Default is \code{TRUE}.}
 
 \item{eps}{Threshold below which numerator values are set to 0.}
 
@@ -110,6 +113,9 @@ s <- hstats(fit, X = iris[-1])
 # (for features with strongest overall interactions)
 h2_pairwise(s)
 
+# Drop 0
+h2_pairwise(s, zero = FALSE)
+
 # Absolute measure as alternative
 h2_pairwise(s, normalize = FALSE, squared = FALSE)
 
@@ -117,6 +123,7 @@ h2_pairwise(s, normalize = FALSE, squared = FALSE)
 fit <- lm(as.matrix(iris[1:2]) ~ Petal.Length + Petal.Width * Species, data = iris)
 s <- hstats(fit, X = iris[3:5], verbose = FALSE)
 h2_pairwise(s, plot = TRUE)
+h2_pairwise(s, zero = FALSE, plot = TRUE)
 }
 \references{
 Friedman, Jerome H., and Bogdan E. Popescu. \emph{"Predictive Learning via Rule Ensembles."}

--- a/man/H2_pairwise.Rd
+++ b/man/H2_pairwise.Rd
@@ -112,9 +112,7 @@ s <- hstats(fit, X = iris[-1])
 # Proportion of joint effect coming from pairwise interaction
 # (for features with strongest overall interactions)
 h2_pairwise(s)
-
-# Drop 0
-h2_pairwise(s, zero = FALSE)
+h2_pairwise(s, zero = FALSE)  # Drop 0
 
 # Absolute measure as alternative
 h2_pairwise(s, normalize = FALSE, squared = FALSE)

--- a/man/H2_threeway.Rd
+++ b/man/H2_threeway.Rd
@@ -16,6 +16,7 @@ h2_threeway(object, ...)
   squared = TRUE,
   sort = TRUE,
   top_m = 15L,
+  zero = TRUE,
   eps = 1e-08,
   plot = FALSE,
   fill = "#2b51a1",
@@ -35,6 +36,8 @@ h2_threeway(object, ...)
 (Multioutput is sorted by row means.)}
 
 \item{top_m}{How many rows should be shown? (\code{Inf} to show all.)}
+
+\item{zero}{Should rows with all 0 be shown? Default is \code{TRUE}.}
 
 \item{eps}{Threshold below which numerator values are set to 0.}
 

--- a/man/hstats.Rd
+++ b/man/hstats.Rd
@@ -173,7 +173,7 @@ fit <- lm(Sepal.Length ~ . + Petal.Width:Species, data = iris)
 s <- hstats(fit, X = iris[-1])
 s
 plot(s)
-plot(s, zero = FALSE)  # Drop 0 interaction rows
+plot(s, zero = FALSE)  # Drop 0
 summary(s)
   
 # Absolute pairwise interaction strengths

--- a/man/hstats.Rd
+++ b/man/hstats.Rd
@@ -18,7 +18,7 @@ hstats(object, ...)
   n_max = 300L,
   w = NULL,
   pairwise_m = 5L,
-  threeway_m = pairwise_m,
+  threeway_m = min(pairwise_m, 5L),
   verbose = TRUE,
   ...
 )
@@ -31,7 +31,7 @@ hstats(object, ...)
   n_max = 300L,
   w = NULL,
   pairwise_m = 5L,
-  threeway_m = pairwise_m,
+  threeway_m = min(pairwise_m, 5L),
   verbose = TRUE,
   ...
 )
@@ -44,7 +44,7 @@ hstats(object, ...)
   n_max = 300L,
   w = NULL,
   pairwise_m = 5L,
-  threeway_m = pairwise_m,
+  threeway_m = min(pairwise_m, 5L),
   verbose = TRUE,
   ...
 )
@@ -57,7 +57,7 @@ hstats(object, ...)
   n_max = 300L,
   w = object[["weights"]],
   pairwise_m = 5L,
-  threeway_m = pairwise_m,
+  threeway_m = min(pairwise_m, 5L),
   verbose = TRUE,
   ...
 )
@@ -87,12 +87,12 @@ selected from \code{X}. In this case, set a random seed for reproducibility.}
 \item{pairwise_m}{Number of features for which pairwise statistics are to be
 calculated. The features are selected based on Friedman and Popescu's overall
 interaction strength \eqn{H^2_j}. Set to to 0 to avoid pairwise calculations.
-For multivariate predictions, the union of the column-wise strongest variable
-names is taken. This can lead to very long run-times.}
+For multivariate predictions, the union of the \code{pairwise_m} column-wise
+strongest variable names is taken. This can lead to very long run-times.}
 
-\item{threeway_m}{Same as \code{pairwise_m}, but controlling the number of features for
-which threeway interactions should be calculated. Not larger than \code{pairwise_m}.
-Set to 0 to avoid threeway calculations.}
+\item{threeway_m}{Like \code{pairwise_m}, but controls the feature count for
+three-way interactions. Cannot be larger than \code{pairwise_m}.
+The default is \code{min(pairwise_m, 5)}. Set to 0 to avoid three-way calculations.}
 
 \item{verbose}{Should a progress bar be shown? The default is \code{TRUE}.}
 }
@@ -103,7 +103,8 @@ An object of class "hstats" containing these elements:
 \item \code{w}: Input \code{w} (sampled to \code{n_max} values, or \code{NULL}).
 \item \code{v}: Same as input \code{v}.
 \item \code{f}: Matrix with (centered) predictions \eqn{F}.
-\item \code{mean_f2}: (Weighted) column means of \code{f}. Used to normalize most statistics.
+\item \code{mean_f2}: (Weighted) column means of \code{f}. Used to normalize \eqn{H^2} and
+\eqn{H^2_j}.
 \item \code{F_j}: List of matrices, each representing (centered)
 partial dependence functions \eqn{F_j}.
 \item \code{F_not_j}: List of matrices with (centered) partial dependence
@@ -112,24 +113,23 @@ functions \eqn{F_{\setminus j}} of other features.
 \item \code{pred_names}: Column names of prediction matrix.
 \item \code{h2}: List with numerator and denominator of \eqn{H^2}.
 \item \code{h2_overall}: List with numerator and denominator of \eqn{H^2_j}.
-\item \code{v_pairwise}: Subset of \code{v} with largest \code{h2_overall()} used for pairwise
+\item \code{v_pairwise}: Subset of \code{v} with largest \eqn{H^2_j} used for pairwise
 calculations.
+\item \code{v_pairwise_0}: Like \code{v_pairwise}, but padded to length \code{pairwise_m}.
 \item \code{combs2}: Named list of variable pairs for which pairwise partial
-dependence functions are available. Only if pairwise calculations have been done.
+dependence functions are available.
 \item \code{F_jk}: List of matrices, each representing (centered) bivariate
 partial dependence functions \eqn{F_{jk}}.
-Only if pairwise calculations have been done.
 \item \code{h2_pairwise}: List with numerator and denominator of \eqn{H^2_{jk}}.
 Only if pairwise calculations have been done.
 \item \code{v_threeway}: Subset of \code{v} with largest \code{h2_overall()} used for three-way
 calculations.
+\item \code{v_threeway_0}: Like \code{v_threeway}, but padded to length \code{threeway_m}.
 \item \code{combs3}: Named list of variable triples for which three-way partial
-dependence functions are available. Only if threeway calculations have been done.
+dependence functions are available.
 \item \code{F_jkl}: List of matrices, each representing (centered) three-way
 partial dependence functions \eqn{F_{jkl}}.
-Only if threeway calculations have been done.
 \item \code{h2_threeway}: List with numerator and denominator of \eqn{H^2_{jkl}}.
-Only if threeway calculations have been done.
 }
 }
 \description{
@@ -149,7 +149,7 @@ see \code{\link[=h2_threeway]{h2_threeway()}} for details.
 Furthermore, it allows to calculate an experimental partial dependence based
 measure of feature importance, \eqn{\textrm{PDI}_j^2}. It equals the proportion of
 prediction variability unexplained by other features, see \code{\link[=pd_importance]{pd_importance()}}
-for details. (This statistic is not shown by \code{summary()} or \code{plot()}.)
+for details. This statistic is not shown by \code{summary()} or \code{plot()}.
 
 Instead of using \code{summary()}, interaction statistics can also be obtained via the
 more flexible functions \code{\link[=h2]{h2()}}, \code{\link[=h2_overall]{h2_overall()}}, \code{\link[=h2_pairwise]{h2_pairwise()}}, and
@@ -172,10 +172,11 @@ fit <- lm(Sepal.Length ~ . + Petal.Width:Species, data = iris)
 s <- hstats(fit, X = iris[-1])
 s
 plot(s)
+plot(s, zero = FALSE)  # Drop 0 interaction rows
 summary(s)
   
 # Absolute pairwise interaction strengths
-h2_pairwise(s, normalize = FALSE, squared = FALSE, plot = FALSE)
+h2_pairwise(s, normalize = FALSE, squared = FALSE, plot = FALSE, zero = FALSE)
 
 # MODEL 2: Multi-response linear regression
 fit <- lm(as.matrix(iris[1:2]) ~ Petal.Length + Petal.Width * Species, data = iris)
@@ -192,9 +193,7 @@ summary(s)
 
 # On original scale, we have interactions everywhere...
 s <- hstats(fit, X = iris[-1], type = "response", verbose = FALSE)
-
-# All three types use different denominators
-plot(s, which = 1:3, ncol = 1)
+plot(s, which = 1:3, ncol = 1)  # All three types use different denominators
 
 # All statistics on same scale (of predictions)
 plot(s, which = 1:3, squared = FALSE, normalize = FALSE, facet_scale = "free_y")

--- a/man/hstats.Rd
+++ b/man/hstats.Rd
@@ -111,11 +111,13 @@ partial dependence functions \eqn{F_j}.
 functions \eqn{F_{\setminus j}} of other features.
 \item \code{K}: Number of columns of prediction matrix.
 \item \code{pred_names}: Column names of prediction matrix.
+\item \code{pairwise_m}: Like input \code{pairwise_m}, but capped at \code{length(v)}.
+\item \code{threeway_m}: Like input \code{threeway_m}, but capped at the smaller of
+\code{length(v)} and \code{pairwise_m}.
 \item \code{h2}: List with numerator and denominator of \eqn{H^2}.
 \item \code{h2_overall}: List with numerator and denominator of \eqn{H^2_j}.
 \item \code{v_pairwise}: Subset of \code{v} with largest \eqn{H^2_j} used for pairwise
 calculations.
-\item \code{v_pairwise_0}: Like \code{v_pairwise}, but padded to length \code{pairwise_m}.
 \item \code{combs2}: Named list of variable pairs for which pairwise partial
 dependence functions are available.
 \item \code{F_jk}: List of matrices, each representing (centered) bivariate
@@ -124,7 +126,6 @@ partial dependence functions \eqn{F_{jk}}.
 Only if pairwise calculations have been done.
 \item \code{v_threeway}: Subset of \code{v} with largest \code{h2_overall()} used for three-way
 calculations.
-\item \code{v_threeway_0}: Like \code{v_threeway}, but padded to length \code{threeway_m}.
 \item \code{combs3}: Named list of variable triples for which three-way partial
 dependence functions are available.
 \item \code{F_jkl}: List of matrices, each representing (centered) three-way

--- a/man/pd_importance.Rd
+++ b/man/pd_importance.Rd
@@ -16,6 +16,7 @@ pd_importance(object, ...)
   squared = TRUE,
   sort = TRUE,
   top_m = 15L,
+  zero = TRUE,
   eps = 1e-08,
   plot = FALSE,
   fill = "#2b51a1",
@@ -35,6 +36,8 @@ pd_importance(object, ...)
 (Multioutput is sorted by row means.)}
 
 \item{top_m}{How many rows should be shown? (\code{Inf} to show all.)}
+
+\item{zero}{Should rows with all 0 be shown? Default is \code{TRUE}.}
 
 \item{eps}{Threshold below which numerator values are set to 0.}
 

--- a/man/plot.hstats.Rd
+++ b/man/plot.hstats.Rd
@@ -11,6 +11,7 @@
   squared = TRUE,
   sort = TRUE,
   top_m = 15L,
+  zero = TRUE,
   eps = 1e-08,
   fill = "#2b51a1",
   facet_scales = "free",
@@ -34,6 +35,8 @@ use \code{1:3}.}
 (Multioutput is sorted by row means.)}
 
 \item{top_m}{How many rows should be shown? (\code{Inf} to show all.)}
+
+\item{zero}{Should rows with all 0 be shown? Default is \code{TRUE}.}
 
 \item{eps}{Threshold below which numerator values are set to 0.}
 

--- a/man/summary.hstats.Rd
+++ b/man/summary.hstats.Rd
@@ -10,6 +10,7 @@
   squared = TRUE,
   sort = TRUE,
   top_m = Inf,
+  zero = TRUE,
   eps = 1e-08,
   ...
 )
@@ -26,15 +27,20 @@
 
 \item{top_m}{How many rows should be shown? (\code{Inf} to show all.)}
 
+\item{zero}{Should rows with all 0 be shown? Default is \code{TRUE}.}
+
 \item{eps}{Threshold below which numerator values are set to 0.}
 
 \item{...}{Currently not used.}
 }
 \value{
-An object of class "summary_hstats" representing a named list with statistics.
+An object of class "summary_hstats" representing a named list with statistics
+"h2", "h2_overall", "h2_pairwise", "h2_threeway", and the input flag "normalize".
+Statistics that equal \code{NULL} are omitted from the list.
 }
 \description{
-Summary method for "hstats" object.
+Summary method for "hstats" object. Note that \eqn{H^2} is not affected by
+the arguments \code{normalize} and \code{squared}.
 }
 \seealso{
 See \code{\link[=hstats]{hstats()}} for examples.

--- a/tests/testthat/test_hstats.R
+++ b/tests/testthat/test_hstats.R
@@ -221,7 +221,10 @@ test_that("Statistics react on normalize, (sorting), squaring, and top m", {
     s$h2_overall$num[1:2, , drop = FALSE]
   )
   
-  expect_identical(h2_pairwise(s, sort = FALSE), s$h2_pairwise$num / s$h2_pairwise$denom)
+  expect_identical(
+    h2_pairwise(s, sort = FALSE), 
+    s$h2_pairwise$num / s$h2_pairwise$denom
+  )
   expect_identical(h2_pairwise(s, sort = FALSE, normalize = FALSE), s$h2_pairwise$num)
   expect_identical(
     h2_pairwise(s, sort = FALSE, normalize = FALSE, squared = FALSE), 

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -238,6 +238,9 @@ test_that("postprocess() works for matrix input", {
     postprocess(num = num, denom = 1:2, sort = FALSE), 
       num / cbind(c(1, 1, 1), c(2, 2, 2))
   )
+  
+  expect_equal(postprocess(num = cbind(0:1, 0:1), zero = FALSE), rbind(c(1, 1)))
+  expect_null(postprocess(num = cbind(0, 0), zero = FALSE))
 })
 
 test_that("postprocess() works for vector input", {
@@ -249,6 +252,9 @@ test_that("postprocess() works for vector input", {
   expect_equal(postprocess(num = num, sort = FALSE), num)
   expect_equal(postprocess(num = num, sort = FALSE, top_m = 2), num[1:2])
   expect_equal(postprocess(num = num, squared = FALSE), sqrt(num[3:1]))
+  
+  expect_equal(postprocess(num = 0:1, denom = c(2, 2), zero = FALSE), 0.5)
+  expect_null(postprocess(num = 0, zero = FALSE))
 })
 
 test_that(".zap_small() works for vector input", {


### PR DESCRIPTION
This PR implements the new default that some features with zero interaction will be shown in pairwise/threeway stats (in line with pairwise_m, threeway_m).
- The behaviour can be changed in the statistics functions by setting `zero = FALSE`.
- This change allows the workflow:
      1. Select m most important features `v` via `perm_importance()`
      2. Run e.g. `s <- hstats(..., v = v, ..., pairwise_m = length(v), threeway_m = 0)`
      3. Get *all* pairwise interaction statistics via `h2_pairwise(s)`, including also features without interactions. 