### PR TITLE
Fix swap_dim factor order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hstats
 Title: Interaction Statistics
-Version: 0.4.0
+Version: 1.0.0
 Authors@R: 
     person("Michael", "Mayer", , "mayermichael79@gmail.com", role = c("aut", "cre"))
 Description: Fast, model-agnostic implementation of different H-statistics

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hstats 0.4.0
+# hstats 1.0.0
 
 ## Major changes
 

--- a/R/utils_plot.R
+++ b/R/utils_plot.R
@@ -30,14 +30,16 @@ get_color_scale <- function(x) {
 #' @noRd
 #' @keywords internal
 #' @param df A data.frame.
+#' @param group Should the group variable "varying_" be reverted too? Default is `TRUE`.
 #' 
 #' @returns A data.frame with reverted factor levels.
-barplot_reverter <- function(df) {
-  transform(
-    df, 
-    variable_ = factor(variable_, levels = rev(levels(variable_))),
-    varying_ = factor(varying_, levels = rev(levels(varying_)))
-  )
+barplot_reverter <- function(df, group = TRUE) {
+  x <-  c("variable_", if (group) "varying_")
+  for (z in x) {
+    f <- df[[z]]
+    df[[z]] <- factor(f, levels = rev(levels(f)))
+  }
+  df
 }
 
 #' Stack some Columns

--- a/R/utils_statistics.R
+++ b/R/utils_statistics.R
@@ -310,7 +310,7 @@ plot.hstats_matrix <- function(x, top_m = 15L,
   if (err_type != "No") {
     df[["error_"]] <- mat2df(err)[["value_"]]
   }
-  df <- barplot_reverter(df)
+  df <- barplot_reverter(df, group = !swap_dim)
   
   if (is.null(viridis_args)) {
     viridis_args <- list()

--- a/packaging.R
+++ b/packaging.R
@@ -15,7 +15,7 @@ library(usethis)
 use_description(
   fields = list(
     Title = "Interaction Statistics",
-    Version = "0.4.0",
+    Version = "1.0.0",
     Description = "Fast, model-agnostic implementation of different H-statistics
     introduced by Jerome H. Friedman and Bogdan E. Popescu (2008) <doi:10.1214/07-AOAS148>. 
     These statistics quantify interaction strength per feature, feature pair, 


### PR DESCRIPTION
Using horizontal dodged barplots requires factor levels to be reverted for both y and fill aesthetic. 

When `swap_dim = TRUE`, the fill aesthetic does not need to be reverted. This PR fixes this.