### PR TITLE
Missing values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 - `average_loss()` is more flexible regarding the group `BY` argument. It can also be a variable *name*. Non-discrete `BY` variables are now automatically binned. Like `partial_dep()`, binning is controlled by the `by_size = 4` argument.
 - `average_loss()` also returns a "hstats_matrix" object with `print()` and `plot()` method. The values can be extracted via `$M`.
 - The default `v` of `hstats()` and `perm_importance()` is now `NULL`. Internally, it is set to `colnames(X)` (minus the column names of `w` and `y` if passed as name).
+- Missing grid values: `partial_dep()` and `ice()` have received a `na.rm = TRUE` argument that controls if missing values are dropped during grid creation. The default is compatible with earlier releases.
 
 # hstats 0.3.0
 

--- a/R/ice.R
+++ b/R/ice.R
@@ -59,7 +59,8 @@ ice <- function(object, ...) {
 ice.default <- function(object, v, X, pred_fun = stats::predict,
                         BY = NULL, grid = NULL, grid_size = 49L,
                         trim = c(0.01, 0.99),
-                        strategy = c("uniform", "quantile"), n_max = 100L, ...) {
+                        strategy = c("uniform", "quantile"), na.rm = TRUE,
+                        n_max = 100L, ...) {
   stopifnot(
     is.matrix(X) || is.data.frame(X),
     is.function(pred_fun),
@@ -69,7 +70,7 @@ ice.default <- function(object, v, X, pred_fun = stats::predict,
   # Prepare grid
   if (is.null(grid)) {
     grid <- multivariate_grid(
-      x = X[, v], grid_size = grid_size, trim = trim, strategy = strategy
+      x = X[, v], grid_size = grid_size, trim = trim, strategy = strategy, na.rm = na.rm
     )
   } else {
     check_grid(g = grid, v = v, X_is_matrix = is.matrix(X))
@@ -142,7 +143,8 @@ ice.ranger <- function(object, v, X,
                        pred_fun = function(m, X, ...) stats::predict(m, X, ...)$predictions,
                        BY = NULL, grid = NULL, grid_size = 49L,
                        trim = c(0.01, 0.99),
-                       strategy = c("uniform", "quantile"), n_max = 100, ...) {
+                       strategy = c("uniform", "quantile"), na.rm = TRUE,
+                       n_max = 100, ...) {
   ice.default(
     object = object,
     v = v,
@@ -153,6 +155,7 @@ ice.ranger <- function(object, v, X,
     grid_size = grid_size,
     trim = trim,
     strategy = strategy,
+    na.rm = na.rm,
     n_max = n_max,
     ...
   )
@@ -163,7 +166,8 @@ ice.ranger <- function(object, v, X,
 ice.Learner <- function(object, v, X,
                         pred_fun = NULL,
                         BY = NULL, grid = NULL, grid_size = 49L, trim = c(0.01, 0.99),
-                        strategy = c("uniform", "quantile"), n_max = 100L, ...) {
+                        strategy = c("uniform", "quantile"), na.rm = TRUE,
+                        n_max = 100L, ...) {
   if (is.null(pred_fun)) {
     pred_fun <- mlr3_pred_fun(object, X = X)
   }
@@ -177,6 +181,7 @@ ice.Learner <- function(object, v, X,
     grid_size = grid_size,
     trim = trim,
     strategy = strategy,
+    na.rm = na.rm,
     n_max = n_max,
     ...
   )
@@ -188,7 +193,8 @@ ice.explainer <- function(object, v = v, X = object[["data"]],
                           pred_fun = object[["predict_function"]],
                           BY = NULL, grid = NULL, grid_size = 49L,
                           trim = c(0.01, 0.99),
-                          strategy = c("uniform", "quantile"), n_max = 100, ...) {
+                          strategy = c("uniform", "quantile"), na.rm = TRUE,
+                          n_max = 100, ...) {
   ice.default(
     object = object[["model"]],
     v = v,
@@ -199,6 +205,7 @@ ice.explainer <- function(object, v = v, X = object[["data"]],
     grid_size = grid_size,
     trim = trim,
     strategy = strategy,
+    na.rm = na.rm,
     n_max = n_max,
     ...
   )

--- a/R/partial_dep.R
+++ b/R/partial_dep.R
@@ -99,8 +99,8 @@ partial_dep <- function(object, ...) {
 partial_dep.default <- function(object, v, X, pred_fun = stats::predict, 
                                 BY = NULL, by_size = 4L, grid = NULL, grid_size = 49L, 
                                 trim = c(0.01, 0.99), 
-                                strategy = c("uniform", "quantile"), n_max = 1000L, 
-                                w = NULL, ...) {
+                                strategy = c("uniform", "quantile"), na.rm = TRUE,
+                                n_max = 1000L, w = NULL, ...) {
   stopifnot(
     is.matrix(X) || is.data.frame(X),
     is.function(pred_fun),
@@ -110,7 +110,7 @@ partial_dep.default <- function(object, v, X, pred_fun = stats::predict,
   # Care about grid
   if (is.null(grid)) {
     grid <- multivariate_grid(
-      x = X[, v], grid_size = grid_size, trim = trim, strategy = strategy
+      x = X[, v], grid_size = grid_size, trim = trim, strategy = strategy, na.rm = na.rm
     )
   } else {
     check_grid(g = grid, v = v, X_is_matrix = is.matrix(X))
@@ -130,7 +130,7 @@ partial_dep.default <- function(object, v, X, pred_fun = stats::predict,
       out <- partial_dep.default(
         object = object, 
         v = v, 
-        X = X[BY2$BY %in% b, , drop = FALSE], 
+        X = X[BY2$BY %in% b, , drop = FALSE],  # works also when by is NA
         pred_fun = pred_fun,
         grid = grid,
         n_max = n_max, 
@@ -185,8 +185,8 @@ partial_dep.ranger <- function(object, v, X,
                                pred_fun = function(m, X, ...) stats::predict(m, X, ...)$predictions,
                                BY = NULL, by_size = 4L, grid = NULL, grid_size = 49L, 
                                trim = c(0.01, 0.99), 
-                               strategy = c("uniform", "quantile"), n_max = 1000L, 
-                               w = NULL, ...) {
+                               strategy = c("uniform", "quantile"), na.rm = TRUE,
+                               n_max = 1000L, w = NULL, ...) {
   partial_dep.default(
     object = object,
     v = v,
@@ -198,6 +198,7 @@ partial_dep.ranger <- function(object, v, X,
     grid_size = grid_size,
     trim = trim,
     strategy = strategy,
+    na.rm = na.rm,
     n_max = n_max,
     w = w,
     ...
@@ -210,8 +211,8 @@ partial_dep.Learner <- function(object, v, X,
                                 pred_fun = NULL,
                                 BY = NULL, by_size = 4L, grid = NULL, grid_size = 49L, 
                                 trim = c(0.01, 0.99), 
-                                strategy = c("uniform", "quantile"), n_max = 1000L, 
-                                w = NULL, ...) {
+                                strategy = c("uniform", "quantile"), na.rm = TRUE,
+                                n_max = 1000L, w = NULL, ...) {
   if (is.null(pred_fun)) {
     pred_fun <- mlr3_pred_fun(object, X = X)
   }
@@ -226,6 +227,7 @@ partial_dep.Learner <- function(object, v, X,
     grid_size = grid_size,
     trim = trim,
     strategy = strategy,
+    na.rm = na.rm,
     n_max = n_max,
     w = w,
     ...
@@ -238,8 +240,8 @@ partial_dep.explainer <- function(object, v, X = object[["data"]],
                                   pred_fun = object[["predict_function"]],
                                   BY = NULL, by_size = 4L, grid = NULL, grid_size = 49L, 
                                   trim = c(0.01, 0.99), 
-                                  strategy = c("uniform", "quantile"), n_max = 1000L, 
-                                  w = object[["weights"]], ...) {
+                                  strategy = c("uniform", "quantile"), na.rm = TRUE,
+                                  n_max = 1000L, w = object[["weights"]], ...) {
   partial_dep.default(
     object = object[["model"]],
     v = v,
@@ -251,6 +253,7 @@ partial_dep.explainer <- function(object, v, X = object[["data"]],
     grid_size = grid_size,
     trim = trim,
     strategy = strategy,
+    na.rm = na.rm,
     n_max = n_max,
     w = w,
     ...

--- a/R/utils_calculate.R
+++ b/R/utils_calculate.R
@@ -82,7 +82,7 @@ wrowmean <- function(x, ngroups = 1L, w = NULL) {
   }
   list(
     X = X[!X_dup, , drop = FALSE], 
-    w = c(rowsum(w, group = x_not_v, reorder = FALSE))
+    w = c(rowsum(w, group = x_not_v, reorder = FALSE))  # warning if missing in x_not_v
   )
 }
 

--- a/man/ice.Rd
+++ b/man/ice.Rd
@@ -20,6 +20,7 @@ ice(object, ...)
   grid_size = 49L,
   trim = c(0.01, 0.99),
   strategy = c("uniform", "quantile"),
+  na.rm = TRUE,
   n_max = 100L,
   ...
 )
@@ -34,6 +35,7 @@ ice(object, ...)
   grid_size = 49L,
   trim = c(0.01, 0.99),
   strategy = c("uniform", "quantile"),
+  na.rm = TRUE,
   n_max = 100,
   ...
 )
@@ -48,6 +50,7 @@ ice(object, ...)
   grid_size = 49L,
   trim = c(0.01, 0.99),
   strategy = c("uniform", "quantile"),
+  na.rm = TRUE,
   n_max = 100L,
   ...
 )
@@ -62,6 +65,7 @@ ice(object, ...)
   grid_size = 49L,
   trim = c(0.01, 0.99),
   strategy = c("uniform", "quantile"),
+  na.rm = TRUE,
   n_max = 100,
   ...
 )
@@ -102,6 +106,8 @@ of grid values. Set to \code{0:1} for no trimming.}
 
 \item{strategy}{How to find grid values of non-discrete numeric columns?
 Either "uniform" or "quantile", see description of \code{\link[=univariate_grid]{univariate_grid()}}.}
+
+\item{na.rm}{Should missing values be dropped from grid? Default is \code{TRUE}.}
 
 \item{n_max}{If \code{X} has more than \code{n_max} rows, a random sample of \code{n_max} rows is
 selected from \code{X}. In this case, set a random seed for reproducibility.}

--- a/man/multivariate_grid.Rd
+++ b/man/multivariate_grid.Rd
@@ -8,7 +8,8 @@ multivariate_grid(
   x,
   grid_size = 49L,
   trim = c(0.01, 0.99),
-  strategy = c("uniform", "quantile")
+  strategy = c("uniform", "quantile"),
+  na.rm = TRUE
 )
 }
 \arguments{
@@ -23,6 +24,8 @@ of grid values. Set to \code{0:1} for no trimming.}
 
 \item{strategy}{How to find grid values of non-discrete numeric columns?
 Either "uniform" or "quantile", see description of \code{\link[=univariate_grid]{univariate_grid()}}.}
+
+\item{na.rm}{Should missing values be dropped from grid? Default is \code{TRUE}.}
 }
 \value{
 A vector, matrix, or data.frame with evaluation points.

--- a/man/partial_dep.Rd
+++ b/man/partial_dep.Rd
@@ -21,6 +21,7 @@ partial_dep(object, ...)
   grid_size = 49L,
   trim = c(0.01, 0.99),
   strategy = c("uniform", "quantile"),
+  na.rm = TRUE,
   n_max = 1000L,
   w = NULL,
   ...
@@ -37,6 +38,7 @@ partial_dep(object, ...)
   grid_size = 49L,
   trim = c(0.01, 0.99),
   strategy = c("uniform", "quantile"),
+  na.rm = TRUE,
   n_max = 1000L,
   w = NULL,
   ...
@@ -53,6 +55,7 @@ partial_dep(object, ...)
   grid_size = 49L,
   trim = c(0.01, 0.99),
   strategy = c("uniform", "quantile"),
+  na.rm = TRUE,
   n_max = 1000L,
   w = NULL,
   ...
@@ -69,6 +72,7 @@ partial_dep(object, ...)
   grid_size = 49L,
   trim = c(0.01, 0.99),
   strategy = c("uniform", "quantile"),
+  na.rm = TRUE,
   n_max = 1000L,
   w = object[["weights"]],
   ...
@@ -116,6 +120,8 @@ of grid values. Set to \code{0:1} for no trimming.}
 
 \item{strategy}{How to find grid values of non-discrete numeric columns?
 Either "uniform" or "quantile", see description of \code{\link[=univariate_grid]{univariate_grid()}}.}
+
+\item{na.rm}{Should missing values be dropped from grid? Default is \code{TRUE}.}
 
 \item{n_max}{If \code{X} has more than \code{n_max} rows, a random sample of \code{n_max} rows is
 selected from \code{X}. In this case, set a random seed for reproducibility.}

--- a/man/univariate_grid.Rd
+++ b/man/univariate_grid.Rd
@@ -8,7 +8,8 @@ univariate_grid(
   z,
   grid_size = 49L,
   trim = c(0.01, 0.99),
-  strategy = c("uniform", "quantile")
+  strategy = c("uniform", "quantile"),
+  na.rm = TRUE
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ of grid values. Set to \code{0:1} for no trimming.}
 
 \item{strategy}{How to find grid values of non-discrete numeric columns?
 Either "uniform" or "quantile", see description of \code{\link[=univariate_grid]{univariate_grid()}}.}
+
+\item{na.rm}{Should missing values be dropped from grid? Default is \code{TRUE}.}
 }
 \value{
 A vector or factor of evaluation points.

--- a/tests/testthat/test_missing_values.R
+++ b/tests/testthat/test_missing_values.R
@@ -1,0 +1,204 @@
+x <- c(NA, 1:98, NA)
+y <- c(rep(c("A", "B"), each = 48), c(NA, NA, NA, NA))
+xy <- data.frame(x = x, y = y)
+
+test_that("univariate_grid() can deal with missings", {
+  expect_true(
+    !anyNA(univariate_grid(x, grid_size = 3, strategy = "uniform", na.rm = TRUE))
+  )
+  expect_true(
+    !anyNA(univariate_grid(x, grid_size = 3, strategy = "quantile", na.rm = TRUE))
+  )
+  expect_true(
+    anyNA(univariate_grid(x, grid_size = 3, strategy = "uniform", na.rm = FALSE))
+  )
+  expect_true(
+    anyNA(univariate_grid(x, grid_size = 3, strategy = "quantile", na.rm = FALSE))
+  )
+  expect_false(
+    anyNA(univariate_grid(na.omit(x), grid_size = 3, strategy = "uniform", na.rm = FALSE))
+  )
+  expect_false(
+    anyNA(univariate_grid(na.omit(x), grid_size = 3, strategy = "quantile", na.rm = FALSE))
+  )
+  
+  expect_true(!anyNA(univariate_grid(y, na.rm = TRUE)))
+  expect_true(anyNA(univariate_grid(y, na.rm = FALSE)))
+  expect_false(anyNA(univariate_grid(na.omit(y), na.rm = FALSE)))
+})
+
+test_that("multivariate_grid() can deal with missings", {
+  expect_true(
+    !anyNA(multivariate_grid(xy, grid_size = 6, strategy = "uniform", na.rm = TRUE))
+  )
+  expect_false(
+    !anyNA(multivariate_grid(xy, grid_size = 6, strategy = "uniform", na.rm = FALSE))
+  )
+  expect_false(
+    anyNA(multivariate_grid(na.omit(xy), grid_size = 6, strategy = "uniform", na.rm = FALSE))
+  )
+})
+
+# Univariate model
+X <- data.frame(x1 = 1:6, x2 = c(NA, 1, 2, 1, 1, 3), x3 = factor(c("A", NA, NA, "B", "A", "A")))
+y <- 1:6
+pf <- function(fit, x) x$x1
+fit <- "a model"
+
+test_that("average_loss() works without BY", {
+  expect_equal(drop(average_loss(fit, X = X, y = y, pred_fun = pf)$M), 0)
+})
+
+test_that("average_loss() works with BY", {
+  expect_warning(
+    expect_warning(r <- average_loss(fit, X = X, y = y, pred_fun = pf, BY = "x3"))
+  )
+  expect_equal(unname(drop(r$M)), c(0, 0, 0))
+  expect_s3_class(plot(r), "ggplot")
+})
+
+test_that("perm_importance() works", {
+  set.seed(1L)
+  expect_no_error(r <- perm_importance(fit, X = X, y = y, pred_fun = pf))
+  expect_true(r$M[1L] > 0 && all(r$M[2:3] == 0))
+})
+
+test_that("ice() works when non-v variable contains missing", {
+  set.seed(1L)
+  expect_no_error(r <- ice(fit, v = "x1", X = X, pred_fun = pf))
+  expect_equal(r$data$x1, r$data$y)
+})
+
+test_that("ice() works when v contains missing", {
+  expect_no_error(r1 <- ice(fit, v = "x2", X = X, pred_fun = pf))
+  expect_true(!anyNA(r1$data$x2))
+  
+  expect_no_error(r2 <- ice(fit, v = "x2", X = X, pred_fun = pf, na.rm = FALSE))
+  expect_true(anyNA(r2$data$x2))
+  
+  expect_equal(r1$data[1:3, ], r2$data[1:3, ])
+  expect_s3_class(plot(r2, alpha = 1), "ggplot")
+})
+
+test_that("ice() works when v contains missing (multivariate)", {
+  v <- c("x2", "x3")
+  
+  expect_no_error(r1 <- ice(fit, v = v, X = X, pred_fun = pf))
+  expect_true(!anyNA(r1$data$x2))
+  
+  expect_no_error(r2 <- ice(fit, v = v, X = X, pred_fun = pf, na.rm = FALSE))
+  expect_true(anyNA(r2$data$x2))
+})
+
+test_that("ice() works with missing value in BY", {
+  expect_true(anyNA(ice(fit, v = "x1", X = X, pred_fun = pf, BY = "x3")$data$x3))
+  r <- ice(fit, v = "x2", X = X, pred_fun = pf, BY = "x3")
+  expect_true(anyNA(r$data$x3))
+  expect_s3_class(plot(r), "ggplot")
+})
+
+test_that("partial_dep() works when non-v variable contains missing", {
+  expect_no_error(r <- partial_dep(fit, v = "x1", X = X, pred_fun = pf))
+  expect_equal(r$data$x1, r$data$y)
+})
+
+test_that("partial_dep() works when v contains missing", {
+  expect_no_error(r1 <- partial_dep(fit, v = "x2", X = X, pred_fun = pf, grid_size = 2))
+  expect_true(!anyNA(r1$data$x2))
+  
+  expect_no_error(
+    r2 <- partial_dep(fit, v = "x2", X = X, pred_fun = pf, na.rm = FALSE, grid_size = 2)
+  )
+  expect_true(anyNA(r2$data$x2))
+  expect_equal(r1$data, r2$data[1:2, ])
+  expect_s3_class(plot(r2), "ggplot")
+})
+
+test_that("partial_dep() works when v contains missing (multi)", {
+  v <- c("x2", "x3")
+  expect_no_error(r1 <- partial_dep(fit, v = v, X = X, pred_fun = pf))
+  expect_true(!anyNA(r1$data$x2))
+  
+  expect_no_error(
+    r2 <- partial_dep(fit, v = v, X = X, pred_fun = pf, na.rm = FALSE)
+  )
+  expect_true(anyNA(r2$data$x2))
+  expect_s3_class(plot(r2), "ggplot")
+})
+
+test_that("partial_dep() works when BY variable contains missing", {
+  expect_no_error(
+    r <- partial_dep(fit, v = "x2", X = X, pred_fun = pf, BY = "x3", na.rm = FALSE)
+  )
+  expect_true(anyNA(r$data$x3))
+  expect_s3_class(plot(r), "ggplot")
+})
+
+pfi <- function(fit, x) ifelse(is.na(x$x1 * x$x2), 1, x$x1 * x$x2)
+
+test_that("hstats() does not give an error with missing", {
+  expect_warning(
+    expect_warning(
+      expect_warning(
+        expect_no_error(
+          r <- hstats(fit, X = X, pred_fun = pfi, verbose = FALSE)
+        )
+      )
+    )
+  )
+  expect_true(drop(r$h2$num) > 0)
+  expect_equal(rownames(h2_pairwise(r, zero = FALSE)), "x1:x2")
+})
+
+# Some checks on pd_raw()
+
+test_that(".compress_grid() works with missing values in grid", {
+  g <- c(2, 2, NA, 1, NA)
+  gg <- .compress_grid(g)
+  expect_equal(gg$grid[gg$reindex], g)
+  
+  g <- cbind(c(2, 2, NA, 1, NA), c(NA, NA, 3, 4, 4))
+  gg <- .compress_grid(g)
+  expect_equal(gg$grid[gg$reindex, , drop = FALSE], g)
+  
+  g <- data.frame(g)
+  gg <- .compress_grid(g)
+  res <- gg$grid[gg$reindex, , drop = FALSE]
+  rownames(res) <- 1:5
+  expect_equal(res, g)
+})
+
+test_that(".compress_X() works with missing values", {
+  # Note that b is not used after compression
+  
+  # data.frame
+  X <- data.frame(a = c(NA, NA, NA, 1, 1), b = 1:5)
+  out_df <- data.frame(a = c(NA, 1), b = c(1, 4), row.names = c(1L, 4L))
+  expect_warning(out <- .compress_X(X, v = "b"))
+  expect_equal(out$X, out_df)
+  expect_equal(out$w, c(3, 2))
+  
+  # Matrix
+  X <- cbind(a = c(NA, NA, NA, 1, 1), b = 1:5)
+  out_m <- cbind(a = c(NA, 1), b = c(1, 4))
+  expect_warning(out <- .compress_X(X, v = "b"))
+  expect_equal(out$X, out_m)
+  expect_equal(out$w, c(3, 2))
+})
+
+test_that("pd_raw() works with missings (all compressions on)", {
+  X <- cbind(a = c(NA, NA, NA, 1, 1), b = 1:5)
+  out <- pd_raw(1, v = "a", X = X, pred_fun = function(m, x) x[, "b"], grid = c(NA, 1))
+  expect_equal(drop(out), rep(mean(X[, "b"]), times = 2L))
+  
+  expect_warning(
+    out <- pd_raw(1, v = "b", X = X, pred_fun = function(m, x) x[, "b"], grid = 1:5)
+  )
+  expect_equal(drop(out), 1:5)
+})
+
+# Other utils
+
+test_that("qcut() works with missings", {
+  expect_true(is.na(hstats:::qcut(c(NA, 1:9), m = 2)[1L]))
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -215,14 +215,6 @@ test_that("wcenter() works for vectors", {
   expect_equal(wcenter(x, w = w), xpected)
 })
 
-test_that("basic_checks fire some errors", {
-  expect_error(basic_check(X = 1:3, v = "a", pred_fun = predict, w = NULL))
-  expect_error(basic_check(X = iris[0], v = "a", pred_fun = predict, w = NULL))
-  expect_error(basic_check(X = iris, v = "a", pred_fun = predict, w = NULL))
-  expect_error(basic_check(X = iris, v = "Species", pred_fun = "mean", w = NULL))
-  expect_error(basic_check(X = iris, v = "Species", pred_fun = predict, w = 1:3))
-})
-
 test_that("poor_man_stack() works (test could be improved", {
   y <- c("a", "b", "c")
   z <- c("aa", "bb", "cc")

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -89,7 +89,6 @@ test_that(".compress_X() works for matrices", {
   expect_equal(out_w2$w, c(9, 6))
 })
 
-
 test_that(".compress_X() leaves X unchanged if unique", {
   X <- data.frame(a = 1:5, b = rep(1, times = 5))
   out <- .compress_X(X, v = "b")


### PR DESCRIPTION
This PR improves handling of missing values:

- Grid values in `ice()` and `partial_dep()` can now include missings (set `na.rm = FALSE`).
- Unit tests for different functions working with missing values

Note that `hstats()` and `average_loss()` give a warning on missing values coming from `rowsum()` (when the group variable contains missings). It is harmless, still we might add some workaround later.