### PR TITLE
Rowsum warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 - `average_loss()` also returns a "hstats_matrix" object with `print()` and `plot()` method. The values can be extracted via `$M`.
 - The default `v` of `hstats()` and `perm_importance()` is now `NULL`. Internally, it is set to `colnames(X)` (minus the column names of `w` and `y` if passed as name).
 - Missing grid values: `partial_dep()` and `ice()` have received a `na.rm` argument that controls if missing values are dropped during grid creation. The default `TRUE` is compatible with earlier releases.
+- Missing values in `hstats()`: Discrete variables with missings would cause `rowsum()` to launch repeated warnings. This case is now catched.
 - The position of some function arguments have changed.
 
 # hstats 0.3.0

--- a/R/pd_raw.R
+++ b/R/pd_raw.R
@@ -115,14 +115,17 @@ ice_raw <- function(object, v, X, grid, pred_fun = stats::predict,
   if (!any(X_dup)) {
     return(list(X = X, w = w))  # No optimization done
   }
-  
-  # Compress
+
+  # Compensate via w
   if (is.null(w)) {
     w <- rep(1.0, times = nrow(X))
   }
+  if (anyNA(x_not_v)) {  # rowsum() warns about NA in group -> integer encode
+    x_not_v <- match(x_not_v, unique(x_not_v))
+  }
   list(
     X = X[!X_dup, , drop = FALSE], 
-    w = c(rowsum(w, group = x_not_v, reorder = FALSE))  # warning if missing in x_not_v
+    w = c(rowsum(w, group = x_not_v, reorder = FALSE))
   )
 }
 

--- a/R/pd_raw.R
+++ b/R/pd_raw.R
@@ -120,8 +120,9 @@ ice_raw <- function(object, v, X, grid, pred_fun = stats::predict,
   if (is.null(w)) {
     w <- rep(1.0, times = nrow(X))
   }
-  if (anyNA(x_not_v)) {  # rowsum() warns about NA in group -> integer encode
-    x_not_v <- match(x_not_v, unique(x_not_v))
+  if (anyNA(x_not_v)) {
+    # rowsum() warns about NA in group = x_not_v -> integer encode
+    x_not_v <- match(x_not_v, x_not_v[!X_dup])
   }
   list(
     X = X[!X_dup, , drop = FALSE], 

--- a/README.md
+++ b/README.md
@@ -102,11 +102,10 @@ average_loss(fit, X = X_valid, y = y_valid)
 Let's calculate different H-statistics via `hstats()`:
 
 ```r
-# 4 seconds on simple laptop - a random forest will take 2-3 minutes
-# With quant_approx = 25 (dense features are binned into 25 bins): 1.5 s
+# 4 seconds on simple laptop - a random forest will take 2 minutes
 set.seed(782)
 system.time(
-  s <- hstats(fit, X = X_train)
+  s <- hstats(fit, X = X_train)  #, approx = TRUE: twice as fast
 )
 s
 # H^2 (normalized)


### PR DESCRIPTION
Fix the repeated warnings from rowsum() when the grouping variable has missings. 

Exception: `average_loss()`. There, a missing BY variable will still produce the warning, which seems ok.