### PR TITLE
make a separate input checker for hstats

### DIFF
--- a/R/hstats.R
+++ b/R/hstats.R
@@ -199,7 +199,7 @@ hstats.default <- function(
   }
   
   # Predictions ("F" in Friedman and Popescu) always calculated (cheap)
-  f <- wcenter(prepare_pred(pred_fun(object, X, ...)), w = w)
+  f <- wcenter(prepare_hstat_pred(pred_fun(object, X, ...)), w = w)
   mean_f2 <- wcolMeans(f^2, w = w)  # A vector
   
   # Initialize first progress bar

--- a/R/utils_input.R
+++ b/R/utils_input.R
@@ -20,6 +20,50 @@ prepare_pred <- function(x) {
   return(x)
 }
 
+prepare_hstat_pred <- function(x) {
+
+  x <- check_numeric_predictions(x)
+  
+  if (is.data.frame(x) && ncol(x) == 1L) {
+    x <- x[[1L]]
+  }
+  
+  if (!is.vector(x) && !is.matrix(x)) {
+    x <- as.matrix(x)
+  }
+  return(x)
+}
+
+# check to see if factor or non-numeric columns exist
+check_numeric_predictions <- function(x) {
+  if (is.vector(x) | is.factor(x)) {
+    if (!is.numeric(x)) {
+      stop("Predictions must be numeric", call. = FALSE)
+    }
+    return(x)
+  }
+  
+  if (is.matrix(x)) {
+    x <- as.data.frame(x)
+  }
+  
+  is_factor <- vapply(x, is.factor, logical(1))
+  is_non_num <- !vapply(x, is.numeric, logical(1))
+  bad_data <- is_factor | is_non_num
+  if (all(bad_data)) {
+    stop("Predictions must be numeric", call. = FALSE)
+  }
+  
+  if (any(bad_data)) {
+    bad_cols <- paste0("`", names(bad_data)[bad_data], "`", collapse = ", ")
+    x <- x[, !bad_data, drop = FALSE]
+    msg <- "Predictions must be numeric. Dropped column(s):"
+    warning(paste(msg, bad_cols), call. = FALSE)
+  }
+  
+  x
+}
+
 #' Prepares Group BY Variable
 #' 
 #' Internal function that prepares a BY variable or BY column name.

--- a/tests/testthat/test_input.R
+++ b/tests/testthat/test_input.R
@@ -5,6 +5,25 @@ test_that("prepare_pred() works", {
   expect_equal(prepare_pred(iris["Sepal.Width"]), iris$Sepal.Width)
 })
 
+test_that("prepare_hstat_pred() works", {
+  expect_equal(hstats::prepare_hstat_pred(iris[1:4]), data.matrix(iris[1:4]))
+  expect_error(
+    hstats::prepare_hstat_pred(iris["Species"]),
+    regexp = "must be numeric"
+  )
+  expect_warning(hstats::prepare_hstat_pred(iris), regexp = "must be numeric")
+  expect_warning(
+    hstats::prepare_hstat_pred(iris[, 4:5]),
+    regexp = "must be numeric"
+  )
+  expect_equal(hstats::prepare_hstat_pred(iris$Sepal.Width), iris$Sepal.Width)
+  expect_equal(
+    hstats::prepare_hstat_pred(iris["Sepal.Width"]),
+    iris$Sepal.Width
+  )
+})
+
+
 test_that("prepare_w() works", {
   w1 <- prepare_w(iris$Sepal.Length, X = iris)
   w2 <- prepare_w("Sepal.Length", X = iris)


### PR DESCRIPTION
@mayer79 This is incomplete; I'm looking for feedback. 

I originally updated 'prepare_pred()' to allow probabilistic classification predictions (in the presence of a factor/hard class prediction), but the change broke other functions (such as `average_loss()`). 

I created a separate input checker called `prepare_hstat_pred()` and only invoke it in `hstats.default()`, but that broke other unit tests in `test_hstats.R`. 

I'm happy to proceed but would need some recommendations; it looks like the checking logic is more complex than what was outlined in #129.  

Please advise. If it's easier, please go ahead and edit the PR to do the right thing. 

